### PR TITLE
Fix typos in specification

### DIFF
--- a/IPtypes.html
+++ b/IPtypes.html
@@ -132,7 +132,7 @@
         <tr class="table-primary"><th colspan="2">Dataset As A Collection Of Data <span class="badge badge-primary float-right">Class</span></th></tr>
         <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/Dataset_As_A_Collection_Of_Data">http://purl.org/cg/terms/Dataset_As_A_Collection_Of_Data</a></td></tr>
         <tr><td class="theme-label">Definition</td><td>??</td></tr>
-        <tr><td class="theme-label">Comments</td><td>Marlo</td></tr>
+        <tr><td class="theme-label">Comments</td><td>MARLO</td></tr>
         <tr><td class="theme-label">Examples</td><td></td></tr>
     </tbody>
 </table>
@@ -372,7 +372,7 @@
         <tr class="table-primary"><th colspan="2">Press Item <span class="badge badge-primary float-right">Class</span></th></tr>
         <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/Press_Item">http://purl.org/cg/terms/Press_Item</a></td></tr>
         <tr><td class="theme-label">Definition</td><td>??</td></tr>
-        <tr><td class="theme-label">Comments</td><td>CGSPACE</td></tr>
+        <tr><td class="theme-label">Comments</td><td>CGSpace</td></tr>
         <tr><td class="theme-label">Examples</td><td></td></tr>
     </tbody>
 </table>

--- a/IPtypes.html
+++ b/IPtypes.html
@@ -86,7 +86,7 @@
     <tbody>
         <tr class="table-primary"><th colspan="2">KOS <span class="badge badge-primary float-right">Class</span></th></tr>
         <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/KOS">http://purl.org/cg/terms/KOS</a></td></tr>
-        <tr><td class="theme-label">Definition</td><td>Supertype for any kind of knowledge organization system such as taxonomies, ontologies, subject headings, classifications, etc.</td></tr>
+        <tr><td class="theme-label">Definition</td><td>Super-type for any kind of knowledge organisation system such as taxonomies, ontologies, subject headings, classifications, etc.</td></tr>
         <tr><td class="theme-label">Comments</td><td>wikipedia</td></tr>
         <tr><td class="theme-label">Examples</td><td></td></tr>
     </tbody>
@@ -251,7 +251,7 @@
     <tbody>
         <tr class="table-primary"><th colspan="2">Brochure <span class="badge badge-primary float-right">Class</span></th></tr>
         <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/Brochure">http://purl.org/cg/terms/Brochure</a></td></tr>
-        <tr><td class="theme-label">Definition</td><td>Pamphlet, booklet, leaflets and other pocket, foldable graphic and informative products containing summarized or introductory information or advertising.</td></tr>
+        <tr><td class="theme-label">Definition</td><td>Pamphlet, booklet, leaflets and other pocket, foldable graphic and informative products containing summarised or introductory information or advertising.</td></tr>
         <tr><td class="theme-label">Comments</td><td>MEL</td></tr>
         <tr><td class="theme-label">Examples</td><td></td></tr>
     </tbody>
@@ -431,7 +431,7 @@
     <tbody>
         <tr class="table-primary"><th colspan="2">Journal Article <span class="badge badge-primary float-right">Class</span></th></tr>
         <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/Journal_Article">http://purl.org/cg/terms/Journal_Article</a></td></tr>
-        <tr><td class="theme-label">Definition</td><td>An article, typically the realization of a research paper reporting original research findings, published in a journal issue.</td></tr>
+        <tr><td class="theme-label">Definition</td><td>An article, typically the realisation of a research paper reporting original research findings, published in a journal issue.</td></tr>
         <tr><td class="theme-label">Comments</td><td>FaBiO</td></tr>
         <tr><td class="theme-label">Examples</td><td></td></tr>
     </tbody>
@@ -506,7 +506,7 @@
     <tbody>
         <tr class="table-primary"><th colspan="2">Newsletter <span class="badge badge-primary float-right">Class</span></th></tr>
         <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/Newsletter">http://purl.org/cg/terms/Newsletter</a></td></tr>
-        <tr><td class="theme-label">Definition</td><td>The Newsletters promote research activities to the community and the university. mobilize knowledge to improve practice and inform policy, and provide relevant and accessible information to the broader public.</td></tr>
+        <tr><td class="theme-label">Definition</td><td>The Newsletters promote research activities to the community and the university. mobilise knowledge to improve practice and inform policy, and provide relevant and accessible information to the broader public.</td></tr>
         <tr><td class="theme-label">Comments</td><td>CASRAI</td></tr>
         <tr><td class="theme-label">Examples</td><td></td></tr>
     </tbody>
@@ -521,7 +521,7 @@
     <tbody>
         <tr class="table-primary"><th colspan="2">Infographic <span class="badge badge-primary float-right">Class</span></th></tr>
         <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/Infographic">http://purl.org/cg/terms/Infographic</a></td></tr>
-        <tr><td class="theme-label">Definition</td><td>Infographics (a clipped compound of information and graphics) are graphic visual representations of information, data or knowledge intended to present information quickly and clearly.They can improve cognition by utilizing graphics to enhance the human visual system's ability to see patterns and trends.</td></tr>
+        <tr><td class="theme-label">Definition</td><td>Infographics (a clipped compound of information and graphics) are graphic visual representations of information, data or knowledge intended to present information quickly and clearly.They can improve cognition by utilising graphics to enhance the human visual system's ability to see patterns and trends.</td></tr>
         <tr><td class="theme-label">Comments</td><td>MARLO</td></tr>
         <tr><td class="theme-label">Examples</td><td></td></tr>
     </tbody>
@@ -596,7 +596,7 @@
     <tbody>
         <tr class="table-primary"><th colspan="2">Conference Paper <span class="badge badge-primary float-right">Class</span></th></tr>
         <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/Conference_Paper">http://purl.org/cg/terms/Conference_Paper</a></td></tr>
-        <tr><td class="theme-label">Definition</td><td>A paper, typically the realization of a research paper reporting original research findings, usually published within a conference proceedings volume.</td></tr>
+        <tr><td class="theme-label">Definition</td><td>A paper, typically the realisation of a research paper reporting original research findings, usually published within a conference proceedings volume.</td></tr>
         <tr><td class="theme-label">Comments</td><td>FaBiO</td></tr>
         <tr><td class="theme-label">Examples</td><td></td></tr>
     </tbody>
@@ -641,7 +641,7 @@
     <tbody>
         <tr class="table-primary"><th colspan="2">Personal Communication <span class="badge badge-primary float-right">Class</span></th></tr>
         <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/Personal_Communication">http://purl.org/cg/terms/Personal_Communication</a></td></tr>
-        <tr><td class="theme-label">Definition</td><td>Information communicated personally by verbal or written means from one individual to one or more another persons or organizations.</td></tr>
+        <tr><td class="theme-label">Definition</td><td>Information communicated personally by verbal or written means from one individual to one or more another persons or organisations.</td></tr>
         <tr><td class="theme-label">Comments</td><td>FabiO</td></tr>
         <tr><td class="theme-label">Examples</td><td></td></tr>
     </tbody>

--- a/cgcore.html
+++ b/cgcore.html
@@ -21,7 +21,7 @@
             <div id="titleP">
                 <h1 id="cgcoremetadatareferenceguide">CG Core metadata reference guide</h1>
                 <p>This page provides a list of the metadata elements that are used in the CG Core metadata schema. The CG Core metadata schema is an application profile and is built from existing standards as much as possible. It is an effort led by the Big Data Platform Metadata Working Group of the CGIAR.</p>
-                <p>The CG Core aims at describing all types of information products that are published by the different CGIAR centers. There are many benefits of having a clear and harmonised way to describe information products:
+                <p>The CG Core aims at describing all types of information products that are published by the different CGIAR centres. There are many benefits of having a clear and harmonised way to describe information products:
                     <li>better interoperability</li>
                     <li>better transparency</li>
                     <li>easy monitoring</li>
@@ -93,7 +93,7 @@
                     <tr class="table-secondary"><th colspan="2">description <span class="badge badge-secondary float-right">Property</span></th></tr>
                     <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/dc/terms/description">http://purl.org/dc/terms/description</a></td></tr>
                     <tr><td class="theme-label">Definition</td><td>Description may include but is not limited to: an abstract, a table of contents, a graphical representation, or a free-text account of the resource.</td></tr>
-                    <tr><td class="theme-label">Comments</td><td>Descriptive details significantly improve discoverability via search engines such as Google and Bing, and will aid interlinkages between related resources at the meta-search/indexer level.
+                    <tr><td class="theme-label">Comments</td><td>Descriptive details significantly improve discoverability via search engines such as Google and Bing, and will aid interlink between related resources at the meta-search/indexer level.
             Descriptions can be provided in multiple languages if appropriate and available. </td></tr>
                     <tr><td class="theme-label">Examples</td><td></td></tr>
                 </tbody>
@@ -145,7 +145,7 @@
                 <tbody>
                     <tr class="table-secondary"><th colspan="2">rightsHolder <span class="badge badge-secondary float-right">Property</span></th></tr>
                     <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/dc/terms/rightsHolder">http://purl.org/dc/terms/rightsHolder</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>A person or organization owning or managing rights over the resource.</td></tr>
+                    <tr><td class="theme-label">Definition</td><td>A person or organisation owning or managing rights over the resource.</td></tr>
                     <tr><td class="theme-label">Comments</td><td></td></tr>
                     <tr><td class="theme-label">Examples</td><td><code>CIAT</code></td></tr>
                 </tbody>
@@ -336,7 +336,7 @@
                 <tbody>
                     <tr class="table-primary"><th colspan="2">Contributor <span class="badge badge-primary float-right">Class</span></th></tr>
                     <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/Contributor">http://purl.org/cg/terms/Contributor</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>Organization, or service making contributions to the information product.</td></tr>
+                    <tr><td class="theme-label">Definition</td><td>Organisation, or service making contributions to the information product.</td></tr>
                     <tr><td class="theme-label">Comments</td><td>describe one of the following: "Project", "Project Lead Center", "Partner", "CRP", "Donor"</td></tr>
                     <tr><td class="theme-label">Examples</td><td></td></tr>
                 </tbody>

--- a/cgcore.html
+++ b/cgcore.html
@@ -41,7 +41,7 @@
             <h2 id="informationproduct">Information product</h2>
 
             <div class="my-4">
-                    <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:identfier">identifer</a>
+                    <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:identfier">identifier</a>
                     <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:title">title</a>
                     <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:description">description</a>
                     <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:type">type</a>
@@ -172,7 +172,7 @@
                     <tr class="table-secondary"><th colspan="2">subject <span class="badge badge-secondary float-right">Property</span></th></tr>
                     <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/dc/terms/subject">http://purl.org/dc/terms/subject</a></td></tr>
                     <tr><td class="theme-label">Definition</td><td>keywords describing the subject of the information product.</td></tr>
-                    <tr><td class="theme-label">Comments</td><td>To be used to link the resouce to one or more concept</td></tr>
+                    <tr><td class="theme-label">Comments</td><td>To be used to link the resource to one or more concept</td></tr>
                     <tr><td class="theme-label">Examples</td><td></td></tr>
                 </tbody>
             </table>
@@ -210,7 +210,7 @@
                 <tbody>
                     <tr class="table-secondary"><th colspan="2">creator <span class="badge badge-secondary float-right">Property</span></th></tr>
                     <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/dc/terms/creator">http://purl.org/dc/terms/creator</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>To be used to link the resouce to one or more creator objects</td></tr>
+                    <tr><td class="theme-label">Definition</td><td>To be used to link the resource to one or more creator objects</td></tr>
                     <tr><td class="theme-label">Comments</td><td>This term is intended to be used with non-literal values</td></tr>
                     <tr><td class="theme-label">Examples</td><td></td></tr>
                 </tbody>
@@ -223,7 +223,7 @@
                 <tbody>
                     <tr class="table-secondary"><th colspan="2">contributor <span class="badge badge-secondary float-right">Property</span></th></tr>
                     <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/dc/terms/contributor">http://purl.org/dc/terms/contributor</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>To be used to link the resouce to one or more contributor objects</td></tr>
+                    <tr><td class="theme-label">Definition</td><td>To be used to link the resource to one or more contributor objects</td></tr>
                     <tr><td class="theme-label">Comments</td><td>This term is intended to be used with non-literal values</td></tr>
                     <tr><td class="theme-label">Examples</td><td></td></tr>
                 </tbody>
@@ -236,7 +236,7 @@
                 <tbody>
                     <tr class="table-secondary"><th colspan="2">coverage <span class="badge badge-secondary float-right">Property</span></th></tr>
                     <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/dc/terms/coverage">http://purl.org/dc/terms/coverage</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>To be used to link the resouce to one or more coverage objects</td></tr>
+                    <tr><td class="theme-label">Definition</td><td>To be used to link the resource to one or more coverage objects</td></tr>
                     <tr><td class="theme-label">Comments</td><td>This term is intended to be used with non-literal values</td></tr>
                     <tr><td class="theme-label">Examples</td><td></td></tr>
                 </tbody>
@@ -271,7 +271,7 @@
             <h2 id="Creator">Creator</h2>
 
             <div class="my-4">
-                    <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:identifer">identifer</a>
+                    <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:identifier">identifier</a>
                     <a class="btn btn-sm btn-outline-secondary m-1" href="#cg:affiliation">affiliation</a>
                     <a class="btn btn-sm btn-outline-secondary m-1" href="#cg:creator name">name</a>
                 </div>
@@ -287,11 +287,11 @@
             </table>
 
             <p class="invisible">
-                <a id="dcterms:identifer"></a><a id="identifer"></a></p>
+                <a id="dcterms:identifier"></a><a id="identifer"></a></p>
 
             <table class="table table-sm table-bordered">
                 <tbody>
-                    <tr class="table-secondary"><th colspan="2">identifer <span class="badge badge-secondary float-right">Property</span></th></tr>
+                    <tr class="table-secondary"><th colspan="2">identifier <span class="badge badge-secondary float-right">Property</span></th></tr>
                     <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/dc/terms/identifier">http://purl.org/dc/terms/identifier</a></td></tr>
                     <tr><td class="theme-label">Definition</td><td>ORCID</td></tr>
                     <tr><td class="theme-label">Comments</td><td></td></tr>
@@ -446,11 +446,11 @@
             </table>
 
             <p class="invisible">
-                <a id="cgcoverage identifier"></a><a id="identifer"></a></p>
+                <a id="cgcoverage identifier"></a><a id="identifier"></a></p>
 
             <table class="table table-sm table-bordered">
                 <tbody>
-                    <tr class="table-secondary"><th colspan="2">Identifer<span class="badge badge-secondary float-right">Property</span></th></tr>
+                    <tr class="table-secondary"><th colspan="2">Identifier<span class="badge badge-secondary float-right">Property</span></th></tr>
                     <tr><td class="theme-label">Identifier</td><td><a href="ttp://purl.org/dc/terms/identifier">http://purl.org/dc/terms/identifier</a></td></tr>
                     <tr><td class="theme-label">Definition</td><td>Identifier of the spatial unit</td></tr>
                     <tr><td class="theme-label">Comments</td><td></td></tr>
@@ -547,7 +547,7 @@
                     <tr class="table-secondary"><th colspan="2">bibliographicCitation <span class="badge badge-secondary float-right">Property</span></th></tr>
                     <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/dc/terms/bibliographicCitation">http://purl.org/dc/terms/bibliographicCitation</a></td></tr>
                     <tr><td class="theme-label">Definition</td><td>A bibliographic reference for the resource</td></tr>
-                    <tr><td class="theme-label">Comments</td><td>Recommended practice is to include sufficient bibliographic detail to identify the resource as unambiguously as possible. Refines <a href="http://purl.org/dc/terms/identifier">dct:identifer</a></td></tr>
+                    <tr><td class="theme-label">Comments</td><td>Recommended practice is to include sufficient bibliographic detail to identify the resource as unambiguously as possible. Refines <a href="http://purl.org/dc/terms/identifier">dct:identifier</a></td></tr>
                     <tr><td class="theme-label">Examples</td><td></td></tr>
                 </tbody>
             </table>
@@ -559,7 +559,7 @@
                 <tbody>
                     <tr class="table-secondary"><th colspan="2">peer-reviewed <span class="badge badge-secondary float-right">Property</span></th></tr>
                     <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/peer-reviewed">http://purl.org/cg/terms/peer-reviewed</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>If the resouce has been peer reviewed</td></tr>
+                    <tr><td class="theme-label">Definition</td><td>If the resource has been peer reviewed</td></tr>
                     <tr><td class="theme-label">Comments</td><td></td></tr>
                     <tr><td class="theme-label">Examples</td><td>yes/no</td></tr>
                 </tbody>
@@ -689,7 +689,7 @@
                 <tbody>
                     <tr class="table-secondary"><th colspan="2">notes <span class="badge badge-secondary float-right">Property</span></th></tr>
                     <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/notes">http://purl.org/cg/terms/notes</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>Miscellaneous extra information retlated to a scientifc publication </td></tr>
+                    <tr><td class="theme-label">Definition</td><td>Miscellaneous extra information related to a scientific publication </td></tr>
                     <tr><td class="theme-label">Comments</td><td></td></tr>
                     <tr><td class="theme-label">Examples</td><td></td></tr>
                 </tbody>
@@ -700,7 +700,7 @@
             <div class="my-4">
                     <a class="btn btn-sm btn-outline-secondary m-1" href="#cg:label">label</a>
                     <a class="btn btn-sm btn-outline-secondary m-1" href="#cg:vocab">vocab</a>
-                    <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:identifer">identifer</a>
+                    <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:identifier">identifier</a>
                 </div>
 
             <table class="table table-sm table-bordered">
@@ -721,7 +721,7 @@
                     <tr class="table-secondary"><th colspan="2">Label <span class="badge badge-secondary float-right">Property</span></th></tr>
                     <tr><td class="theme-label">Identifier</td><td><a href="http://www.w3.org/2000/01/rdf-schema#label">http://www.w3.org/2000/01/rdf-schema#label</a></td></tr>
                     <tr><td class="theme-label">Definition</td><td>The label of the concept</td></tr>
-                    <tr><td class="theme-label">Comments</td><td>Should be the prefered label if a concept has several labels</td></tr>
+                    <tr><td class="theme-label">Comments</td><td>Should be the preferred label if a concept has several labels</td></tr>
                     <tr><td class="theme-label">Examples</td><td></td></tr>
                 </tbody>
             </table>
@@ -734,17 +734,17 @@
                     <tr class="table-secondary"><th colspan="2">vocab <span class="badge badge-secondary float-right">Property</span></th></tr>
                     <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/vocab">http://purl.org/cg/terms/vocab</a></td></tr>
                     <tr><td class="theme-label">Definition</td><td>Source of the concept</td></tr>
-                    <tr><td class="theme-label">Comments</td><td>One of the following: Agrovoc, GACS, AgrO, CO</td></tr>
-                    <tr><td class="theme-label">Examples</td><td>Agrovoc</td></tr>
+                    <tr><td class="theme-label">Comments</td><td>One of the following: AGROVOC, GACS, AgrO, CO</td></tr>
+                    <tr><td class="theme-label">Examples</td><td>AGROVOC</td></tr>
                 </tbody>
             </table>
 
             <p class="invisible">
-                <a id="dcterms:identifer"></a><a id="identifer"></a></p>
+                <a id="dcterms:identifier"></a><a id="identifer"></a></p>
 
             <table class="table table-sm table-bordered">
                 <tbody>
-                    <tr class="table-secondary"><th colspan="2">identifer <span class="badge badge-secondary float-right">Property</span></th></tr>
+                    <tr class="table-secondary"><th colspan="2">identifier <span class="badge badge-secondary float-right">Property</span></th></tr>
                     <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/dc/terms/identifier">http://purl.org/dc/terms/identifier</a></td></tr>
                     <tr><td class="theme-label">Definition</td><td>URI of the concept</td></tr>
                     <tr><td class="theme-label">Comments</td><td></td></tr>


### PR DESCRIPTION
Checked with hunspell and aspell in Linux command line. This mostly fixes some real typos like "identifer" and "resouce", but also normalizes some acronyms like CGSpace, AGROVOC, and MARLO.

For the language, eventually we could normalize against en_GB or en_US because it's currently a bit of both right now (ie "harmonised" and "organization"). This is easy in Linux:

```
$ aspell check -d en_GB
```