### PR TITLE
HTML syntax fixes

### DIFF
--- a/cgcore.html
+++ b/cgcore.html
@@ -82,7 +82,7 @@
                     <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/dc/terms/title">http://purl.org/dc/terms/title</a></td></tr>
                     <tr><td class="theme-label">Definition</td><td>A name given to the resource</td></tr>
                     <tr><td class="theme-label">Comments</td><td>Follow standard title formatting for capitalization and punctuation.</td></tr>
-                    <tr><td class="theme-label">Examples</td><td><code>'Managing for timber and biodiversity in the Congo basin' -- 'A 2007 Social Accounting Matrix for China' -- '2012 Global Hunger Index Data'<code></td></tr>
+                    <tr><td class="theme-label">Examples</td><td><code>'Managing for timber and biodiversity in the Congo basin' -- 'A 2007 Social Accounting Matrix for China' -- '2012 Global Hunger Index Data'</code></td></tr>
                 </tbody>
             </table>
 
@@ -776,7 +776,7 @@
                     <tr class="table-secondary"><th colspan="2">isPartOf <span class="badge badge-secondary float-right">Property</span></th></tr>
                     <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/dc/terms/isPartOf">http://purl.org/dc/terms/isPartOf</a></td></tr>
                     <tr><td class="theme-label">Definition</td><td>A related resource in which the described resource is physically or logically included</td></tr>
-                    <tr><td class="theme-label">Comments</td><td>Should be used to link a book to a series</a></td></tr>
+                    <tr><td class="theme-label">Comments</td><td>Should be used to link a book to a series</td></tr>
                     <tr><td class="theme-label">Examples</td><td></td></tr>
                 </tbody>
             </table>

--- a/cgcore.html
+++ b/cgcore.html
@@ -21,11 +21,12 @@
             <div id="titleP">
                 <h1 id="cgcoremetadatareferenceguide">CG Core metadata reference guide</h1>
                 <p>This page provides a list of the metadata elements that are used in the CG Core metadata schema. The CG Core metadata schema is an application profile and is built from existing standards as much as possible. It is an effort led by the Big Data Platform Metadata Working Group of the CGIAR.</p>
-                <p>The CG Core aims at describing all types of information products that are published by the different CGIAR centres. There are many benefits of having a clear and harmonised way to describe information products:
+                <p>The CG Core aims at describing all types of information products that are published by the different CGIAR centres. There are many benefits of having a clear and harmonised way to describe information products:</p>
+                <ul>
                     <li>better interoperability</li>
                     <li>better transparency</li>
                     <li>easy monitoring</li>
-                </p>
+                </ul>
                 <p>This document provides guidelines on how to use the CG Core metadata schema and provides examples on how to use it. A RDF version of the application profile will be available soon.</p>
             </div>
             <div class="my">
@@ -350,9 +351,10 @@
                     <tr class="table-secondary"><th colspan="2">name <span class="badge badge-secondary float-right">Property</span></th></tr>
                     <tr><td class="theme-label">Identifier</td><td><a href="http://xmlns.com/foaf/0.1/name">http://xmlns.com/foaf/0.1/name</a></td></tr>
                     <tr><td class="theme-label">Definition</td><td>The name identifying the contributor</td></tr>
-                    <tr><td class="theme-label">Comments</td><td><li>for donors, recommendation to use <a href="https://www.crossref.org/services/funder-registry/"> crossref Donors registry</a></li>
+                    <tr><td class="theme-label">Comments</td><td><ul><li>for donors, recommendation to use <a href="https://www.crossref.org/services/funder-registry/"> crossref Donors registry</a></li>
                     <li>for CRPs and Project Lead Center, recommendation to use <a href="https://clarisa.cgiar.org/api/cgiar-entities">CLARISA entity list</a></li>
                     <li>for partners, recommendation to use <a href="https://clarisa.cgiar.org/api/institutions">CLARISA institution list</a> </li>
+                    </ul>
                     </td></tr>
                     <tr><td class="theme-label">Examples</td><td></td></tr>
                 </tbody>


### PR DESCRIPTION
Fix invalid HTML syntax in lists, code, and anchors. Similar to #15, but includes more fixes. There are more warnings if you check with a format validator like `tidy`, but we can get to those later because it will re-format the entire file to standardize indentation!