### PR TITLE
Validate and fix HTML syntax with tidy

### DIFF
--- a/IPtypes.html
+++ b/IPtypes.html
@@ -1,10 +1,11 @@
 <!DOCTYPE html>
 <html>
-    <head>
-        <meta charset="utf-8">
-        <title>CG Core metadata schema</title>
-        <link rel="stylesheet" href="main.css">
-        <style>
+<head>
+  <meta name="generator" content="HTML Tidy for HTML5 for Linux version 5.7.16">
+  <meta charset="utf-8">
+  <title>CG Core metadata schema</title>
+  <link rel="stylesheet" href="main.css">
+  <style>
             table {
             }
             .table .table-sm .table-bordered {
@@ -19,677 +20,1126 @@
                 margin-top: -110px;
             }
 
-        </style>
-    </head>
-    <body>
-        <div id="titleP">
-            <h1 id="cgcoremetadatareferenceguide">Information Products</h1>
-            <p>This page provides the description of the information product types recommended by the CG Core metadata schema </p>
-        </div>
-        <hr />
-        <div class="my">
-            <p class="menu"><a href="cgcore.html">return to cg core main page</a></p>
-        </div>
-        <div class="my-4">
-                <h3>Types of Information Product</h3>
-                <a class="btn btn-sm btn-outline-secondary m-1" href="#kos">KOS</a>
-                <a class="btn btn-sm btn-outline-secondary m-1" href="#datafile">Data file</a>
-                <a class="btn btn-sm btn-outline-secondary m-1" href="#database">Database</a>
-                <a class="btn btn-sm btn-outline-secondary m-1" href="#datasetasacollectionofdata">Dataset As A Collection Of Data</a>
-                <a class="btn btn-sm btn-outline-secondary m-1" href="#geospatialrasterfile">geospatial raster file</a>
-                <a class="btn btn-sm btn-outline-secondary m-1" href="#geospatialvectorfile">geospatial vector file</a>
-                <a class="btn btn-sm btn-outline-secondary m-1" href="#manual">Manual</a>
-                <a class="btn btn-sm btn-outline-secondary m-1" href="#website">Website</a>
-                <a class="btn btn-sm btn-outline-secondary m-1" href="#software">Software</a>
-                <a class="btn btn-sm btn-outline-secondary m-1" href="#image">Image</a>
-                <a class="btn btn-sm btn-outline-secondary m-1" href="#audio">Audio</a>
-                <a class="btn btn-sm btn-outline-secondary m-1" href="#brochure">Brochure</a>
-                <a class="btn btn-sm btn-outline-secondary m-1" href="#directivedocument">directive document</a>
-                <a class="btn btn-sm btn-outline-secondary m-1" href="#legaldocument">Legal Document</a>
-                <a class="btn btn-sm btn-outline-secondary m-1" href="#technicalreport">Technical Report</a>
-                <a class="btn btn-sm btn-outline-secondary m-1" href="#sourcecode">Source Code</a>
-                <a class="btn btn-sm btn-outline-secondary m-1" href="#standard">Standard</a>
-                <a class="btn btn-sm btn-outline-secondary m-1" href="#newsitem">News Item</a>
-                <a class="btn btn-sm btn-outline-secondary m-1" href="#post">post</a>
-                <a class="btn btn-sm btn-outline-secondary m-1" href="#pressitem">Press Item</a>
-                <a class="btn btn-sm btn-outline-secondary m-1" href="#workingpaper">Working Paper</a>
-                <a class="btn btn-sm btn-outline-secondary m-1" href="#map">Map</a>
-                <a class="btn btn-sm btn-outline-secondary m-1" href="#journal(full)">Journal (full)</a>
-                <a class="btn btn-sm btn-outline-secondary m-1" href="#journalarticle">Journal Article</a>
-                <a class="btn btn-sm btn-outline-secondary m-1" href="#poster">Poster</a>
-                <a class="btn btn-sm btn-outline-secondary m-1" href="#other">Other</a>
-                <a class="btn btn-sm btn-outline-secondary m-1" href="#video">Video</a>
-                <a class="btn btn-sm btn-outline-secondary m-1" href="#videorecording">Video Recording</a>
-                <a class="btn btn-sm btn-outline-secondary m-1" href="#newsletter">Newsletter</a>
-                <a class="btn btn-sm btn-outline-secondary m-1" href="#infographic">Infographic</a>
-                <a class="btn btn-sm btn-outline-secondary m-1" href="#newspaper">Newspaper</a>
-                <a class="btn btn-sm btn-outline-secondary m-1" href="#researchreport">Research Report</a>
-                <a class="btn btn-sm btn-outline-secondary m-1" href="#book">Book</a>
-                <a class="btn btn-sm btn-outline-secondary m-1" href="#bookchapter">Book Chapter</a>
-                <a class="btn btn-sm btn-outline-secondary m-1" href="#conferencepaper">Conference Paper</a>
-                <a class="btn btn-sm btn-outline-secondary m-1" href="#conferenceproceedings">Conference Proceedings</a>
-                <a class="btn btn-sm btn-outline-secondary m-1" href="#magazinearticle">Magazine Article</a>
-                <a class="btn btn-sm btn-outline-secondary m-1" href="#personalcommunication">Personal Communication</a>
-                <a class="btn btn-sm btn-outline-secondary m-1" href="#financialreport">Financial Report</a>
-                <a class="btn btn-sm btn-outline-secondary m-1" href="#presentation">Presentation</a>
-                <a class="btn btn-sm btn-outline-secondary m-1" href="#thesis">Thesis</a>
-                
-        </div>
-
-<h2 id="kos">KOS</h2>
-
-<div class="my-4">
-    </div>
-
-<table class="table table-sm table-bordered">
+  </style>
+</head>
+<body>
+  <div id="titleP">
+    <h1 id="cgcoremetadatareferenceguide">Information Products</h1>
+    <p>This page provides the description of the information product types recommended by the CG Core metadata schema</p>
+  </div>
+  <hr>
+  <div class="my">
+    <p class="menu"><a href="cgcore.html">return to cg core main page</a></p>
+  </div>
+  <div class="my-4">
+    <h3>Types of Information Product</h3><a class="btn btn-sm btn-outline-secondary m-1" href="#kos">KOS</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#datafile">Data file</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#database">Database</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#datasetasacollectionofdata">Dataset As A Collection Of Data</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#geospatialrasterfile">geospatial raster file</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#geospatialvectorfile">geospatial vector file</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#manual">Manual</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#website">Website</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#software">Software</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#image">Image</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#audio">Audio</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#brochure">Brochure</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#directivedocument">directive document</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#legaldocument">Legal Document</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#technicalreport">Technical Report</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#sourcecode">Source Code</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#standard">Standard</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#newsitem">News Item</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#post">post</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#pressitem">Press Item</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#workingpaper">Working Paper</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#map">Map</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#journal(full)">Journal (full)</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#journalarticle">Journal Article</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#poster">Poster</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#other">Other</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#video">Video</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#videorecording">Video Recording</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#newsletter">Newsletter</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#infographic">Infographic</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#newspaper">Newspaper</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#researchreport">Research Report</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#book">Book</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#bookchapter">Book Chapter</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#conferencepaper">Conference Paper</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#conferenceproceedings">Conference Proceedings</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#magazinearticle">Magazine Article</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#personalcommunication">Personal Communication</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#financialreport">Financial Report</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#presentation">Presentation</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#thesis">Thesis</a>
+  </div>
+  <h2 id="kos">KOS</h2>
+  <div class="my-4"></div>
+  <table class="table table-sm table-bordered">
     <tbody>
-        <tr class="table-primary"><th colspan="2">KOS <span class="badge badge-primary float-right">Class</span></th></tr>
-        <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/KOS">http://purl.org/cg/terms/KOS</a></td></tr>
-        <tr><td class="theme-label">Definition</td><td>Super-type for any kind of knowledge organisation system such as taxonomies, ontologies, subject headings, classifications, etc.</td></tr>
-        <tr><td class="theme-label">Comments</td><td>wikipedia</td></tr>
-        <tr><td class="theme-label">Examples</td><td></td></tr>
+      <tr class="table-primary">
+        <th colspan="2">KOS <span class="badge badge-primary float-right">Class</span></th>
+      </tr>
+      <tr>
+        <td class="theme-label">Identifier</td>
+        <td>
+          <a href="http://purl.org/cg/terms/KOS">http://purl.org/cg/terms/KOS</a>
+        </td>
+      </tr>
+      <tr>
+        <td class="theme-label">Definition</td>
+        <td>Super-type for any kind of knowledge organisation system such as taxonomies, ontologies, subject headings, classifications, etc.</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Comments</td>
+        <td>wikipedia</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Examples</td>
+        <td></td>
+      </tr>
     </tbody>
-</table>
-
-<h2 id="datafile">Data file</h2>
-
-<div class="my-4">
-    </div>
-
-<table class="table table-sm table-bordered">
+  </table>
+  <h2 id="datafile">Data file</h2>
+  <div class="my-4"></div>
+  <table class="table table-sm table-bordered">
     <tbody>
-        <tr class="table-primary"><th colspan="2">Data file <span class="badge badge-primary float-right">Class</span></th></tr>
-        <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/Data_file">http://purl.org/cg/terms/Data_file</a></td></tr>
-        <tr><td class="theme-label">Definition</td><td>A digital item containing information in computer-readable form encoded in a particular format.</td></tr>
-        <tr><td class="theme-label">Comments</td><td>FaBiO</td></tr>
-        <tr><td class="theme-label">Examples</td><td></td></tr>
+      <tr class="table-primary">
+        <th colspan="2">Data file <span class="badge badge-primary float-right">Class</span></th>
+      </tr>
+      <tr>
+        <td class="theme-label">Identifier</td>
+        <td>
+          <a href="http://purl.org/cg/terms/Data_file">http://purl.org/cg/terms/Data_file</a>
+        </td>
+      </tr>
+      <tr>
+        <td class="theme-label">Definition</td>
+        <td>A digital item containing information in computer-readable form encoded in a particular format.</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Comments</td>
+        <td>FaBiO</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Examples</td>
+        <td></td>
+      </tr>
     </tbody>
-</table>
-
-<h2 id="database">Database</h2>
-
-<div class="my-4">
-    </div>
-
-<table class="table table-sm table-bordered">
+  </table>
+  <h2 id="database">Database</h2>
+  <div class="my-4"></div>
+  <table class="table table-sm table-bordered">
     <tbody>
-        <tr class="table-primary"><th colspan="2">Database <span class="badge badge-primary float-right">Class</span></th></tr>
-        <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/Database">http://purl.org/cg/terms/Database</a></td></tr>
-        <tr><td class="theme-label">Definition</td><td>A structured collection of logically related records or data usually stored and retrieved using computer-based means.</td></tr>
-        <tr><td class="theme-label">Comments</td><td>FaBiO</td></tr>
-        <tr><td class="theme-label">Examples</td><td></td></tr>
+      <tr class="table-primary">
+        <th colspan="2">Database <span class="badge badge-primary float-right">Class</span></th>
+      </tr>
+      <tr>
+        <td class="theme-label">Identifier</td>
+        <td>
+          <a href="http://purl.org/cg/terms/Database">http://purl.org/cg/terms/Database</a>
+        </td>
+      </tr>
+      <tr>
+        <td class="theme-label">Definition</td>
+        <td>A structured collection of logically related records or data usually stored and retrieved using computer-based means.</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Comments</td>
+        <td>FaBiO</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Examples</td>
+        <td></td>
+      </tr>
     </tbody>
-</table>
-
-<h2 id="datasetasacollectionofdata">Dataset As A Collection Of Data</h2>
-
-<div class="my-4">
-    </div>
-
-<table class="table table-sm table-bordered">
+  </table>
+  <h2 id="datasetasacollectionofdata">Dataset As A Collection Of Data</h2>
+  <div class="my-4"></div>
+  <table class="table table-sm table-bordered">
     <tbody>
-        <tr class="table-primary"><th colspan="2">Dataset As A Collection Of Data <span class="badge badge-primary float-right">Class</span></th></tr>
-        <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/Dataset_As_A_Collection_Of_Data">http://purl.org/cg/terms/Dataset_As_A_Collection_Of_Data</a></td></tr>
-        <tr><td class="theme-label">Definition</td><td>??</td></tr>
-        <tr><td class="theme-label">Comments</td><td>MARLO</td></tr>
-        <tr><td class="theme-label">Examples</td><td></td></tr>
+      <tr class="table-primary">
+        <th colspan="2">Dataset As A Collection Of Data <span class="badge badge-primary float-right">Class</span></th>
+      </tr>
+      <tr>
+        <td class="theme-label">Identifier</td>
+        <td>
+          <a href="http://purl.org/cg/terms/Dataset_As_A_Collection_Of_Data">http://purl.org/cg/terms/Dataset_As_A_Collection_Of_Data</a>
+        </td>
+      </tr>
+      <tr>
+        <td class="theme-label">Definition</td>
+        <td>??</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Comments</td>
+        <td>MARLO</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Examples</td>
+        <td></td>
+      </tr>
     </tbody>
-</table>
-
-<h2 id="geospatialrasterfile">geospatial raster file</h2>
-
-<div class="my-4">
-    </div>
-
-<table class="table table-sm table-bordered">
+  </table>
+  <h2 id="geospatialrasterfile">geospatial raster file</h2>
+  <div class="my-4"></div>
+  <table class="table table-sm table-bordered">
     <tbody>
-        <tr class="table-primary"><th colspan="2">geospatial raster file <span class="badge badge-primary float-right">Class</span></th></tr>
-        <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/geospatial_raster_file">http://purl.org/cg/terms/geospatial_raster_file</a></td></tr>
-        <tr><td class="theme-label">Definition</td><td>Dataset made for geospatial machine processing, representation type: raster</td></tr>
-        <tr><td class="theme-label">Comments</td><td>CSI</td></tr>
-        <tr><td class="theme-label">Examples</td><td></td></tr>
+      <tr class="table-primary">
+        <th colspan="2">geospatial raster file <span class="badge badge-primary float-right">Class</span></th>
+      </tr>
+      <tr>
+        <td class="theme-label">Identifier</td>
+        <td>
+          <a href="http://purl.org/cg/terms/geospatial_raster_file">http://purl.org/cg/terms/geospatial_raster_file</a>
+        </td>
+      </tr>
+      <tr>
+        <td class="theme-label">Definition</td>
+        <td>Dataset made for geospatial machine processing, representation type: raster</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Comments</td>
+        <td>CSI</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Examples</td>
+        <td></td>
+      </tr>
     </tbody>
-</table>
-
-<h2 id="geospatialvectorfile">geospatial vector file</h2>
-
-<div class="my-4">
-    </div>
-
-<table class="table table-sm table-bordered">
+  </table>
+  <h2 id="geospatialvectorfile">geospatial vector file</h2>
+  <div class="my-4"></div>
+  <table class="table table-sm table-bordered">
     <tbody>
-        <tr class="table-primary"><th colspan="2">geospatial vector file <span class="badge badge-primary float-right">Class</span></th></tr>
-        <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/geospatial_vector_file">http://purl.org/cg/terms/geospatial_vector_file</a></td></tr>
-        <tr><td class="theme-label">Definition</td><td>Dataset made for geospatial machine processing, representation type: vector</td></tr>
-        <tr><td class="theme-label">Comments</td><td>CSI</td></tr>
-        <tr><td class="theme-label">Examples</td><td></td></tr>
+      <tr class="table-primary">
+        <th colspan="2">geospatial vector file <span class="badge badge-primary float-right">Class</span></th>
+      </tr>
+      <tr>
+        <td class="theme-label">Identifier</td>
+        <td>
+          <a href="http://purl.org/cg/terms/geospatial_vector_file">http://purl.org/cg/terms/geospatial_vector_file</a>
+        </td>
+      </tr>
+      <tr>
+        <td class="theme-label">Definition</td>
+        <td>Dataset made for geospatial machine processing, representation type: vector</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Comments</td>
+        <td>CSI</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Examples</td>
+        <td></td>
+      </tr>
     </tbody>
-</table>
-
-<h2 id="manual">Manual</h2>
-
-<div class="my-4">
-    </div>
-
-<table class="table table-sm table-bordered">
+  </table>
+  <h2 id="manual">Manual</h2>
+  <div class="my-4"></div>
+  <table class="table table-sm table-bordered">
     <tbody>
-        <tr class="table-primary"><th colspan="2">Manual <span class="badge badge-primary float-right">Class</span></th></tr>
-        <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/Manual">http://purl.org/cg/terms/Manual</a></td></tr>
-        <tr><td class="theme-label">Definition</td><td>Course and assignment materials produced for teaching purposes.</td></tr>
-        <tr><td class="theme-label">Comments</td><td>DataCite</td></tr>
-        <tr><td class="theme-label">Examples</td><td></td></tr>
+      <tr class="table-primary">
+        <th colspan="2">Manual <span class="badge badge-primary float-right">Class</span></th>
+      </tr>
+      <tr>
+        <td class="theme-label">Identifier</td>
+        <td>
+          <a href="http://purl.org/cg/terms/Manual">http://purl.org/cg/terms/Manual</a>
+        </td>
+      </tr>
+      <tr>
+        <td class="theme-label">Definition</td>
+        <td>Course and assignment materials produced for teaching purposes.</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Comments</td>
+        <td>DataCite</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Examples</td>
+        <td></td>
+      </tr>
     </tbody>
-</table>
-
-<h2 id="website">Website</h2>
-
-<div class="my-4">
-    </div>
-
-<table class="table table-sm table-bordered">
+  </table>
+  <h2 id="website">Website</h2>
+  <div class="my-4"></div>
+  <table class="table table-sm table-bordered">
     <tbody>
-        <tr class="table-primary"><th colspan="2">Website <span class="badge badge-primary float-right">Class</span></th></tr>
-        <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/Website">http://purl.org/cg/terms/Website</a></td></tr>
-        <tr><td class="theme-label">Definition</td><td>A collection of related web pages containing text, images, videos and/or other digital assets that are addressed relative to a common Uniform Resource Locator (URL). A web site is hosted on at least one web server, accessible via a network such as the Internet or a private local area network.</td></tr>
-        <tr><td class="theme-label">Comments</td><td>FaBiO</td></tr>
-        <tr><td class="theme-label">Examples</td><td></td></tr>
+      <tr class="table-primary">
+        <th colspan="2">Website <span class="badge badge-primary float-right">Class</span></th>
+      </tr>
+      <tr>
+        <td class="theme-label">Identifier</td>
+        <td>
+          <a href="http://purl.org/cg/terms/Website">http://purl.org/cg/terms/Website</a>
+        </td>
+      </tr>
+      <tr>
+        <td class="theme-label">Definition</td>
+        <td>A collection of related web pages containing text, images, videos and/or other digital assets that are addressed relative to a common Uniform Resource Locator (URL). A web site is hosted on at least one web server, accessible via a network such as the Internet or a private local area network.</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Comments</td>
+        <td>FaBiO</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Examples</td>
+        <td></td>
+      </tr>
     </tbody>
-</table>
-
-<h2 id="software">Software</h2>
-
-<div class="my-4">
-    </div>
-
-<table class="table table-sm table-bordered">
+  </table>
+  <h2 id="software">Software</h2>
+  <div class="my-4"></div>
+  <table class="table table-sm table-bordered">
     <tbody>
-        <tr class="table-primary"><th colspan="2">Software <span class="badge badge-primary float-right">Class</span></th></tr>
-        <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/Software">http://purl.org/cg/terms/Software</a></td></tr>
-        <tr><td class="theme-label">Definition</td><td>A computer program in source code (text) or compiled form. </td></tr>
-        <tr><td class="theme-label">Comments</td><td>DataCite</td></tr>
-        <tr><td class="theme-label">Examples</td><td></td></tr>
+      <tr class="table-primary">
+        <th colspan="2">Software <span class="badge badge-primary float-right">Class</span></th>
+      </tr>
+      <tr>
+        <td class="theme-label">Identifier</td>
+        <td>
+          <a href="http://purl.org/cg/terms/Software">http://purl.org/cg/terms/Software</a>
+        </td>
+      </tr>
+      <tr>
+        <td class="theme-label">Definition</td>
+        <td>A computer program in source code (text) or compiled form.</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Comments</td>
+        <td>DataCite</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Examples</td>
+        <td></td>
+      </tr>
     </tbody>
-</table>
-
-<h2 id="image">Image</h2>
-
-<div class="my-4">
-    </div>
-
-<table class="table table-sm table-bordered">
+  </table>
+  <h2 id="image">Image</h2>
+  <div class="my-4"></div>
+  <table class="table table-sm table-bordered">
     <tbody>
-        <tr class="table-primary"><th colspan="2">Image <span class="badge badge-primary float-right">Class</span></th></tr>
-        <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/Image">http://purl.org/cg/terms/Image</a></td></tr>
-        <tr><td class="theme-label">Definition</td><td> A visual representation other than text</td></tr>
-        <tr><td class="theme-label">Comments</td><td>Dublin Core</td></tr>
-        <tr><td class="theme-label">Examples</td><td></td></tr>
+      <tr class="table-primary">
+        <th colspan="2">Image <span class="badge badge-primary float-right">Class</span></th>
+      </tr>
+      <tr>
+        <td class="theme-label">Identifier</td>
+        <td>
+          <a href="http://purl.org/cg/terms/Image">http://purl.org/cg/terms/Image</a>
+        </td>
+      </tr>
+      <tr>
+        <td class="theme-label">Definition</td>
+        <td>A visual representation other than text</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Comments</td>
+        <td>Dublin Core</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Examples</td>
+        <td></td>
+      </tr>
     </tbody>
-</table>
-
-<h2 id="audio">Audio</h2>
-
-<div class="my-4">
-    </div>
-
-<table class="table table-sm table-bordered">
+  </table>
+  <h2 id="audio">Audio</h2>
+  <div class="my-4"></div>
+  <table class="table table-sm table-bordered">
     <tbody>
-        <tr class="table-primary"><th colspan="2">Audio <span class="badge badge-primary float-right">Class</span></th></tr>
-        <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/Audio">http://purl.org/cg/terms/Audio</a></td></tr>
-        <tr><td class="theme-label">Definition</td><td>Resource primarily intended to be heard. Examples include a music playback file format, an audio compact disc, and recorded speech or sounds.</td></tr>
-        <tr><td class="theme-label">Comments</td><td>COAR</td></tr>
-        <tr><td class="theme-label">Examples</td><td></td></tr>
+      <tr class="table-primary">
+        <th colspan="2">Audio <span class="badge badge-primary float-right">Class</span></th>
+      </tr>
+      <tr>
+        <td class="theme-label">Identifier</td>
+        <td>
+          <a href="http://purl.org/cg/terms/Audio">http://purl.org/cg/terms/Audio</a>
+        </td>
+      </tr>
+      <tr>
+        <td class="theme-label">Definition</td>
+        <td>Resource primarily intended to be heard. Examples include a music playback file format, an audio compact disc, and recorded speech or sounds.</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Comments</td>
+        <td>COAR</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Examples</td>
+        <td></td>
+      </tr>
     </tbody>
-</table>
-
-<h2 id="brochure">Brochure</h2>
-
-<div class="my-4">
-    </div>
-
-<table class="table table-sm table-bordered">
+  </table>
+  <h2 id="brochure">Brochure</h2>
+  <div class="my-4"></div>
+  <table class="table table-sm table-bordered">
     <tbody>
-        <tr class="table-primary"><th colspan="2">Brochure <span class="badge badge-primary float-right">Class</span></th></tr>
-        <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/Brochure">http://purl.org/cg/terms/Brochure</a></td></tr>
-        <tr><td class="theme-label">Definition</td><td>Pamphlet, booklet, leaflets and other pocket, foldable graphic and informative products containing summarised or introductory information or advertising.</td></tr>
-        <tr><td class="theme-label">Comments</td><td>MEL</td></tr>
-        <tr><td class="theme-label">Examples</td><td></td></tr>
+      <tr class="table-primary">
+        <th colspan="2">Brochure <span class="badge badge-primary float-right">Class</span></th>
+      </tr>
+      <tr>
+        <td class="theme-label">Identifier</td>
+        <td>
+          <a href="http://purl.org/cg/terms/Brochure">http://purl.org/cg/terms/Brochure</a>
+        </td>
+      </tr>
+      <tr>
+        <td class="theme-label">Definition</td>
+        <td>Pamphlet, booklet, leaflets and other pocket, foldable graphic and informative products containing summarised or introductory information or advertising.</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Comments</td>
+        <td>MEL</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Examples</td>
+        <td></td>
+      </tr>
     </tbody>
-</table>
-
-<h2 id="directivedocument">directive document</h2>
-
-<div class="my-4">
-    </div>
-
-<table class="table table-sm table-bordered">
+  </table>
+  <h2 id="directivedocument">directive document</h2>
+  <div class="my-4"></div>
+  <table class="table table-sm table-bordered">
     <tbody>
-        <tr class="table-primary"><th colspan="2">directive document <span class="badge badge-primary float-right">Class</span></th></tr>
-        <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/directive_document">http://purl.org/cg/terms/directive_document</a></td></tr>
-        <tr><td class="theme-label">Definition</td><td> A work created for the purpose of education or instruction, that may be expressed as a text book, a lecture, a tutorial or an instruction manual.</td></tr>
-        <tr><td class="theme-label">Comments</td><td>FaBiO</td></tr>
-        <tr><td class="theme-label">Examples</td><td></td></tr>
+      <tr class="table-primary">
+        <th colspan="2">directive document <span class="badge badge-primary float-right">Class</span></th>
+      </tr>
+      <tr>
+        <td class="theme-label">Identifier</td>
+        <td>
+          <a href="http://purl.org/cg/terms/directive_document">http://purl.org/cg/terms/directive_document</a>
+        </td>
+      </tr>
+      <tr>
+        <td class="theme-label">Definition</td>
+        <td>A work created for the purpose of education or instruction, that may be expressed as a text book, a lecture, a tutorial or an instruction manual.</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Comments</td>
+        <td>FaBiO</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Examples</td>
+        <td></td>
+      </tr>
     </tbody>
-</table>
-
-<h2 id="legaldocument">Legal Document</h2>
-
-<div class="my-4">
-    </div>
-
-<table class="table table-sm table-bordered">
+  </table>
+  <h2 id="legaldocument">Legal Document</h2>
+  <div class="my-4"></div>
+  <table class="table table-sm table-bordered">
     <tbody>
-        <tr class="table-primary"><th colspan="2">Legal Document <span class="badge badge-primary float-right">Class</span></th></tr>
-        <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/Legal_Document">http://purl.org/cg/terms/Legal_Document</a></td></tr>
-        <tr><td class="theme-label">Definition</td><td>A document that states some contractual relationship or grants some right. For example, a court decision, a brief, and so forth.</td></tr>
-        <tr><td class="theme-label">Comments</td><td>VIVO</td></tr>
-        <tr><td class="theme-label">Examples</td><td></td></tr>
+      <tr class="table-primary">
+        <th colspan="2">Legal Document <span class="badge badge-primary float-right">Class</span></th>
+      </tr>
+      <tr>
+        <td class="theme-label">Identifier</td>
+        <td>
+          <a href="http://purl.org/cg/terms/Legal_Document">http://purl.org/cg/terms/Legal_Document</a>
+        </td>
+      </tr>
+      <tr>
+        <td class="theme-label">Definition</td>
+        <td>A document that states some contractual relationship or grants some right. For example, a court decision, a brief, and so forth.</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Comments</td>
+        <td>VIVO</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Examples</td>
+        <td></td>
+      </tr>
     </tbody>
-</table>
-
-<h2 id="technicalreport">Technical Report</h2>
-
-<div class="my-4">
-    </div>
-
-<table class="table table-sm table-bordered">
+  </table>
+  <h2 id="technicalreport">Technical Report</h2>
+  <div class="my-4"></div>
+  <table class="table table-sm table-bordered">
     <tbody>
-        <tr class="table-primary"><th colspan="2">Technical Report <span class="badge badge-primary float-right">Class</span></th></tr>
-        <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/Technical_Report">http://purl.org/cg/terms/Technical_Report</a></td></tr>
-        <tr><td class="theme-label">Definition</td><td>A report of a technical nature.</td></tr>
-        <tr><td class="theme-label">Comments</td><td>FaBiO</td></tr>
-        <tr><td class="theme-label">Examples</td><td></td></tr>
+      <tr class="table-primary">
+        <th colspan="2">Technical Report <span class="badge badge-primary float-right">Class</span></th>
+      </tr>
+      <tr>
+        <td class="theme-label">Identifier</td>
+        <td>
+          <a href="http://purl.org/cg/terms/Technical_Report">http://purl.org/cg/terms/Technical_Report</a>
+        </td>
+      </tr>
+      <tr>
+        <td class="theme-label">Definition</td>
+        <td>A report of a technical nature.</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Comments</td>
+        <td>FaBiO</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Examples</td>
+        <td></td>
+      </tr>
     </tbody>
-</table>
-
-<h2 id="sourcecode">Source Code</h2>
-
-<div class="my-4">
-    </div>
-
-<table class="table table-sm table-bordered">
+  </table>
+  <h2 id="sourcecode">Source Code</h2>
+  <div class="my-4"></div>
+  <table class="table table-sm table-bordered">
     <tbody>
-        <tr class="table-primary"><th colspan="2">Source Code <span class="badge badge-primary float-right">Class</span></th></tr>
-        <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/Source_Code">http://purl.org/cg/terms/Source_Code</a></td></tr>
-        <tr><td class="theme-label">Definition</td><td>Original sets of executable commands, code strings or text commands, constituting an executable computer program or to be compiled or assembled into an executable computer program.</td></tr>
-        <tr><td class="theme-label">Comments</td><td>MEL</td></tr>
-        <tr><td class="theme-label">Examples</td><td></td></tr>
+      <tr class="table-primary">
+        <th colspan="2">Source Code <span class="badge badge-primary float-right">Class</span></th>
+      </tr>
+      <tr>
+        <td class="theme-label">Identifier</td>
+        <td>
+          <a href="http://purl.org/cg/terms/Source_Code">http://purl.org/cg/terms/Source_Code</a>
+        </td>
+      </tr>
+      <tr>
+        <td class="theme-label">Definition</td>
+        <td>Original sets of executable commands, code strings or text commands, constituting an executable computer program or to be compiled or assembled into an executable computer program.</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Comments</td>
+        <td>MEL</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Examples</td>
+        <td></td>
+      </tr>
     </tbody>
-</table>
-
-<h2 id="standard">Standard</h2>
-
-<div class="my-4">
-    </div>
-
-<table class="table table-sm table-bordered">
+  </table>
+  <h2 id="standard">Standard</h2>
+  <div class="my-4"></div>
+  <table class="table table-sm table-bordered">
     <tbody>
-        <tr class="table-primary"><th colspan="2">Standard <span class="badge badge-primary float-right">Class</span></th></tr>
-        <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/Standard">http://purl.org/cg/terms/Standard</a></td></tr>
-        <tr><td class="theme-label">Definition</td><td>A set of requirements and criteria (for example, quality, dimensions, materials, or protocols) agreed upon and passed by a standards body.</td></tr>
-        <tr><td class="theme-label">Comments</td><td>Citavi</td></tr>
-        <tr><td class="theme-label">Examples</td><td></td></tr>
+      <tr class="table-primary">
+        <th colspan="2">Standard <span class="badge badge-primary float-right">Class</span></th>
+      </tr>
+      <tr>
+        <td class="theme-label">Identifier</td>
+        <td>
+          <a href="http://purl.org/cg/terms/Standard">http://purl.org/cg/terms/Standard</a>
+        </td>
+      </tr>
+      <tr>
+        <td class="theme-label">Definition</td>
+        <td>A set of requirements and criteria (for example, quality, dimensions, materials, or protocols) agreed upon and passed by a standards body.</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Comments</td>
+        <td>Citavi</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Examples</td>
+        <td></td>
+      </tr>
     </tbody>
-</table>
-
-<h2 id="newsitem">News Item</h2>
-
-<div class="my-4">
-    </div>
-
-<table class="table table-sm table-bordered">
+  </table>
+  <h2 id="newsitem">News Item</h2>
+  <div class="my-4"></div>
+  <table class="table table-sm table-bordered">
     <tbody>
-        <tr class="table-primary"><th colspan="2">News Item <span class="badge badge-primary float-right">Class</span></th></tr>
-        <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/News_Item">http://purl.org/cg/terms/News_Item</a></td></tr>
-        <tr><td class="theme-label">Definition</td><td>A short written piece focused on an event or announcement of note, having a defined publication time and of less enduring interest than a news feature.</td></tr>
-        <tr><td class="theme-label">Comments</td><td>VIVO</td></tr>
-        <tr><td class="theme-label">Examples</td><td></td></tr>
+      <tr class="table-primary">
+        <th colspan="2">News Item <span class="badge badge-primary float-right">Class</span></th>
+      </tr>
+      <tr>
+        <td class="theme-label">Identifier</td>
+        <td>
+          <a href="http://purl.org/cg/terms/News_Item">http://purl.org/cg/terms/News_Item</a>
+        </td>
+      </tr>
+      <tr>
+        <td class="theme-label">Definition</td>
+        <td>A short written piece focused on an event or announcement of note, having a defined publication time and of less enduring interest than a news feature.</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Comments</td>
+        <td>VIVO</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Examples</td>
+        <td></td>
+      </tr>
     </tbody>
-</table>
-
-<h2 id="post">Post</h2>
-
-<div class="my-4">
-    </div>
-
-<table class="table table-sm table-bordered">
+  </table>
+  <h2 id="post">Post</h2>
+  <div class="my-4"></div>
+  <table class="table table-sm table-bordered">
     <tbody>
-        <tr class="table-primary"><th colspan="2">Post <span class="badge badge-primary float-right">Class</span></th></tr>
-        <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/post">http://purl.org/cg/terms/post</a></td></tr>
-        <tr><td class="theme-label">Definition</td><td>??</td></tr>
-        <tr><td class="theme-label">Comments</td><td>??</td></tr>
-        <tr><td class="theme-label">Examples</td><td></td></tr>
+      <tr class="table-primary">
+        <th colspan="2">Post <span class="badge badge-primary float-right">Class</span></th>
+      </tr>
+      <tr>
+        <td class="theme-label">Identifier</td>
+        <td>
+          <a href="http://purl.org/cg/terms/post">http://purl.org/cg/terms/post</a>
+        </td>
+      </tr>
+      <tr>
+        <td class="theme-label">Definition</td>
+        <td>??</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Comments</td>
+        <td>??</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Examples</td>
+        <td></td>
+      </tr>
     </tbody>
-</table>
-
-<h2 id="pressitem">Press Item</h2>
-
-<div class="my-4">
-    </div>
-
-<table class="table table-sm table-bordered">
+  </table>
+  <h2 id="pressitem">Press Item</h2>
+  <div class="my-4"></div>
+  <table class="table table-sm table-bordered">
     <tbody>
-        <tr class="table-primary"><th colspan="2">Press Item <span class="badge badge-primary float-right">Class</span></th></tr>
-        <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/Press_Item">http://purl.org/cg/terms/Press_Item</a></td></tr>
-        <tr><td class="theme-label">Definition</td><td>??</td></tr>
-        <tr><td class="theme-label">Comments</td><td>CGSpace</td></tr>
-        <tr><td class="theme-label">Examples</td><td></td></tr>
+      <tr class="table-primary">
+        <th colspan="2">Press Item <span class="badge badge-primary float-right">Class</span></th>
+      </tr>
+      <tr>
+        <td class="theme-label">Identifier</td>
+        <td>
+          <a href="http://purl.org/cg/terms/Press_Item">http://purl.org/cg/terms/Press_Item</a>
+        </td>
+      </tr>
+      <tr>
+        <td class="theme-label">Definition</td>
+        <td>??</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Comments</td>
+        <td>CGSpace</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Examples</td>
+        <td></td>
+      </tr>
     </tbody>
-</table>
-
-<h2 id="workingpaper">Working Paper</h2>
-
-<div class="my-4">
-    </div>
-
-<table class="table table-sm table-bordered">
+  </table>
+  <h2 id="workingpaper">Working Paper</h2>
+  <div class="my-4"></div>
+  <table class="table table-sm table-bordered">
     <tbody>
-        <tr class="table-primary"><th colspan="2">Working Paper <span class="badge badge-primary float-right">Class</span></th></tr>
-        <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/Working_Paper">http://purl.org/cg/terms/Working_Paper</a></td></tr>
-        <tr><td class="theme-label">Definition</td><td>A demonstration paper, typically describing a new product, service or system created as a result of research, usually presented during a conference or workshop.</td></tr>
-        <tr><td class="theme-label">Comments</td><td>FaBiO</td></tr>
-        <tr><td class="theme-label">Examples</td><td></td></tr>
+      <tr class="table-primary">
+        <th colspan="2">Working Paper <span class="badge badge-primary float-right">Class</span></th>
+      </tr>
+      <tr>
+        <td class="theme-label">Identifier</td>
+        <td>
+          <a href="http://purl.org/cg/terms/Working_Paper">http://purl.org/cg/terms/Working_Paper</a>
+        </td>
+      </tr>
+      <tr>
+        <td class="theme-label">Definition</td>
+        <td>A demonstration paper, typically describing a new product, service or system created as a result of research, usually presented during a conference or workshop.</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Comments</td>
+        <td>FaBiO</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Examples</td>
+        <td></td>
+      </tr>
     </tbody>
-</table>
-
-<h2 id="map">Map</h2>
-
-<div class="my-4">
-    </div>
-
-<table class="table table-sm table-bordered">
+  </table>
+  <h2 id="map">Map</h2>
+  <div class="my-4"></div>
+  <table class="table table-sm table-bordered">
     <tbody>
-        <tr class="table-primary"><th colspan="2">Map <span class="badge badge-primary float-right">Class</span></th></tr>
-        <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/Map">http://purl.org/cg/terms/Map</a></td></tr>
-        <tr><td class="theme-label">Definition</td><td>Any material representing the whole or part of the earth or any celestial body at any scale. Cartographic materials include two- and three-dimensional maps and plans (including maps of imaginary places), aeronautical, navigational, and celestial charts, atlases, globes, block diagrams, sections, aerial photographs with a cartographic purpose, bird's-eye views (map views), etc. primarily for human reading, not machine processing</td></tr>
-        <tr><td class="theme-label">Comments</td><td>COAR</td></tr>
-        <tr><td class="theme-label">Examples</td><td></td></tr>
+      <tr class="table-primary">
+        <th colspan="2">Map <span class="badge badge-primary float-right">Class</span></th>
+      </tr>
+      <tr>
+        <td class="theme-label">Identifier</td>
+        <td>
+          <a href="http://purl.org/cg/terms/Map">http://purl.org/cg/terms/Map</a>
+        </td>
+      </tr>
+      <tr>
+        <td class="theme-label">Definition</td>
+        <td>Any material representing the whole or part of the earth or any celestial body at any scale. Cartographic materials include two- and three-dimensional maps and plans (including maps of imaginary places), aeronautical, navigational, and celestial charts, atlases, globes, block diagrams, sections, aerial photographs with a cartographic purpose, bird's-eye views (map views), etc. primarily for human reading, not machine processing</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Comments</td>
+        <td>COAR</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Examples</td>
+        <td></td>
+      </tr>
     </tbody>
-</table>
-
-<h2 id="journalfull">Journal (full)</h2>
-
-<div class="my-4">
-    </div>
-
-<table class="table table-sm table-bordered">
+  </table>
+  <h2 id="journalfull">Journal (full)</h2>
+  <div class="my-4"></div>
+  <table class="table table-sm table-bordered">
     <tbody>
-        <tr class="table-primary"><th colspan="2">Journal (full) <span class="badge badge-primary float-right">Class</span></th></tr>
-        <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/Journal_(full)">http://purl.org/cg/terms/Journal_(full)</a></td></tr>
-        <tr><td class="theme-label">Definition</td><td>A scholarly periodical primarily devoted to the publication of original research papers. [Printed and electronic manifestations of the same journal are usually identified by separate print and electronic International Standard Serial Numbers (ISSN or eISSN, respectively), that identifies the journal as a whole, not to individual issues of it.]</td></tr>
-        <tr><td class="theme-label">Comments</td><td>FaBiO</td></tr>
-        <tr><td class="theme-label">Examples</td><td></td></tr>
+      <tr class="table-primary">
+        <th colspan="2">Journal (full) <span class="badge badge-primary float-right">Class</span></th>
+      </tr>
+      <tr>
+        <td class="theme-label">Identifier</td>
+        <td>
+          <a href="http://purl.org/cg/terms/Journal_(full)">http://purl.org/cg/terms/Journal_(full)</a>
+        </td>
+      </tr>
+      <tr>
+        <td class="theme-label">Definition</td>
+        <td>A scholarly periodical primarily devoted to the publication of original research papers. [Printed and electronic manifestations of the same journal are usually identified by separate print and electronic International Standard Serial Numbers (ISSN or eISSN, respectively), that identifies the journal as a whole, not to individual issues of it.]</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Comments</td>
+        <td>FaBiO</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Examples</td>
+        <td></td>
+      </tr>
     </tbody>
-</table>
-
-<h2 id="journalarticle">Journal Article</h2>
-
-<div class="my-4">
-    </div>
-
-<table class="table table-sm table-bordered">
+  </table>
+  <h2 id="journalarticle">Journal Article</h2>
+  <div class="my-4"></div>
+  <table class="table table-sm table-bordered">
     <tbody>
-        <tr class="table-primary"><th colspan="2">Journal Article <span class="badge badge-primary float-right">Class</span></th></tr>
-        <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/Journal_Article">http://purl.org/cg/terms/Journal_Article</a></td></tr>
-        <tr><td class="theme-label">Definition</td><td>An article, typically the realisation of a research paper reporting original research findings, published in a journal issue.</td></tr>
-        <tr><td class="theme-label">Comments</td><td>FaBiO</td></tr>
-        <tr><td class="theme-label">Examples</td><td></td></tr>
+      <tr class="table-primary">
+        <th colspan="2">Journal Article <span class="badge badge-primary float-right">Class</span></th>
+      </tr>
+      <tr>
+        <td class="theme-label">Identifier</td>
+        <td>
+          <a href="http://purl.org/cg/terms/Journal_Article">http://purl.org/cg/terms/Journal_Article</a>
+        </td>
+      </tr>
+      <tr>
+        <td class="theme-label">Definition</td>
+        <td>An article, typically the realisation of a research paper reporting original research findings, published in a journal issue.</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Comments</td>
+        <td>FaBiO</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Examples</td>
+        <td></td>
+      </tr>
     </tbody>
-</table>
-
-<h2 id="poster">Poster</h2>
-
-<div class="my-4">
-    </div>
-
-<table class="table table-sm table-bordered">
+  </table>
+  <h2 id="poster">Poster</h2>
+  <div class="my-4"></div>
+  <table class="table table-sm table-bordered">
     <tbody>
-        <tr class="table-primary"><th colspan="2">Poster <span class="badge badge-primary float-right">Class</span></th></tr>
-        <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/Poster">http://purl.org/cg/terms/Poster</a></td></tr>
-        <tr><td class="theme-label">Definition</td><td>Opaque (e.g., two-dimensional) art originals and reproductions, charts, photographs or materials intended to be projected or viewed without sound, e.g., filmstrips, transparencies, photographs, posters, pictures, radiographs, slides, and collections of such materials.</td></tr>
-        <tr><td class="theme-label">Comments</td><td>NISO</td></tr>
-        <tr><td class="theme-label">Examples</td><td></td></tr>
+      <tr class="table-primary">
+        <th colspan="2">Poster <span class="badge badge-primary float-right">Class</span></th>
+      </tr>
+      <tr>
+        <td class="theme-label">Identifier</td>
+        <td>
+          <a href="http://purl.org/cg/terms/Poster">http://purl.org/cg/terms/Poster</a>
+        </td>
+      </tr>
+      <tr>
+        <td class="theme-label">Definition</td>
+        <td>Opaque (e.g., two-dimensional) art originals and reproductions, charts, photographs or materials intended to be projected or viewed without sound, e.g., filmstrips, transparencies, photographs, posters, pictures, radiographs, slides, and collections of such materials.</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Comments</td>
+        <td>NISO</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Examples</td>
+        <td></td>
+      </tr>
     </tbody>
-</table>
-
-<h2 id="other">Other</h2>
-
-<div class="my-4">
-    </div>
-
-<table class="table table-sm table-bordered">
+  </table>
+  <h2 id="other">Other</h2>
+  <div class="my-4"></div>
+  <table class="table table-sm table-bordered">
     <tbody>
-        <tr class="table-primary"><th colspan="2">Other <span class="badge badge-primary float-right">Class</span></th></tr>
-        <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/Other">http://purl.org/cg/terms/Other</a></td></tr>
-        <tr><td class="theme-label">Definition</td><td>A rest category which may cover text, interactive, sound, or image-based resources not explicitly addressed in any concept in this vocabulary</td></tr>
-        <tr><td class="theme-label">Comments</td><td>COAR</td></tr>
-        <tr><td class="theme-label">Examples</td><td></td></tr>
+      <tr class="table-primary">
+        <th colspan="2">Other <span class="badge badge-primary float-right">Class</span></th>
+      </tr>
+      <tr>
+        <td class="theme-label">Identifier</td>
+        <td>
+          <a href="http://purl.org/cg/terms/Other">http://purl.org/cg/terms/Other</a>
+        </td>
+      </tr>
+      <tr>
+        <td class="theme-label">Definition</td>
+        <td>A rest category which may cover text, interactive, sound, or image-based resources not explicitly addressed in any concept in this vocabulary</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Comments</td>
+        <td>COAR</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Examples</td>
+        <td></td>
+      </tr>
     </tbody>
-</table>
-
-<h2 id="video">Video</h2>
-
-<div class="my-4">
-    </div>
-
-<table class="table table-sm table-bordered">
+  </table>
+  <h2 id="video">Video</h2>
+  <div class="my-4"></div>
+  <table class="table table-sm table-bordered">
     <tbody>
-        <tr class="table-primary"><th colspan="2">Video <span class="badge badge-primary float-right">Class</span></th></tr>
-        <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/Video">http://purl.org/cg/terms/Video</a></td></tr>
-        <tr><td class="theme-label">Definition</td><td>Moving display, either generated dynamically by a computer program or formed from a series of pre-recorded still images imparting an impression of motion when shown in succession. </td></tr>
-        <tr><td class="theme-label">Comments</td><td>COAR</td></tr>
-        <tr><td class="theme-label">Examples</td><td></td></tr>
+      <tr class="table-primary">
+        <th colspan="2">Video <span class="badge badge-primary float-right">Class</span></th>
+      </tr>
+      <tr>
+        <td class="theme-label">Identifier</td>
+        <td>
+          <a href="http://purl.org/cg/terms/Video">http://purl.org/cg/terms/Video</a>
+        </td>
+      </tr>
+      <tr>
+        <td class="theme-label">Definition</td>
+        <td>Moving display, either generated dynamically by a computer program or formed from a series of pre-recorded still images imparting an impression of motion when shown in succession.</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Comments</td>
+        <td>COAR</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Examples</td>
+        <td></td>
+      </tr>
     </tbody>
-</table>
-
-<h2 id="videorecording">Video Recording</h2>
-
-<div class="my-4">
-    </div>
-
-<table class="table table-sm table-bordered">
+  </table>
+  <h2 id="videorecording">Video Recording</h2>
+  <div class="my-4"></div>
+  <table class="table table-sm table-bordered">
     <tbody>
-        <tr class="table-primary"><th colspan="2">Video Recording <span class="badge badge-primary float-right">Class</span></th></tr>
-        <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/Video_Recording">http://purl.org/cg/terms/Video_Recording</a></td></tr>
-        <tr><td class="theme-label">Definition</td><td>A recording of visual images, usually in motion and with sound accompaniment.</td></tr>
-        <tr><td class="theme-label">Comments</td><td>COAR</td></tr>
-        <tr><td class="theme-label">Examples</td><td></td></tr>
+      <tr class="table-primary">
+        <th colspan="2">Video Recording <span class="badge badge-primary float-right">Class</span></th>
+      </tr>
+      <tr>
+        <td class="theme-label">Identifier</td>
+        <td>
+          <a href="http://purl.org/cg/terms/Video_Recording">http://purl.org/cg/terms/Video_Recording</a>
+        </td>
+      </tr>
+      <tr>
+        <td class="theme-label">Definition</td>
+        <td>A recording of visual images, usually in motion and with sound accompaniment.</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Comments</td>
+        <td>COAR</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Examples</td>
+        <td></td>
+      </tr>
     </tbody>
-</table>
-
-<h2 id="newsletter">Newsletter</h2>
-
-<div class="my-4">
-    </div>
-
-<table class="table table-sm table-bordered">
+  </table>
+  <h2 id="newsletter">Newsletter</h2>
+  <div class="my-4"></div>
+  <table class="table table-sm table-bordered">
     <tbody>
-        <tr class="table-primary"><th colspan="2">Newsletter <span class="badge badge-primary float-right">Class</span></th></tr>
-        <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/Newsletter">http://purl.org/cg/terms/Newsletter</a></td></tr>
-        <tr><td class="theme-label">Definition</td><td>The Newsletters promote research activities to the community and the university. mobilise knowledge to improve practice and inform policy, and provide relevant and accessible information to the broader public.</td></tr>
-        <tr><td class="theme-label">Comments</td><td>CASRAI</td></tr>
-        <tr><td class="theme-label">Examples</td><td></td></tr>
+      <tr class="table-primary">
+        <th colspan="2">Newsletter <span class="badge badge-primary float-right">Class</span></th>
+      </tr>
+      <tr>
+        <td class="theme-label">Identifier</td>
+        <td>
+          <a href="http://purl.org/cg/terms/Newsletter">http://purl.org/cg/terms/Newsletter</a>
+        </td>
+      </tr>
+      <tr>
+        <td class="theme-label">Definition</td>
+        <td>The Newsletters promote research activities to the community and the university. mobilise knowledge to improve practice and inform policy, and provide relevant and accessible information to the broader public.</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Comments</td>
+        <td>CASRAI</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Examples</td>
+        <td></td>
+      </tr>
     </tbody>
-</table>
-
-<h2 id="infographic">Infographic</h2>
-
-<div class="my-4">
-    </div>
-
-<table class="table table-sm table-bordered">
+  </table>
+  <h2 id="infographic">Infographic</h2>
+  <div class="my-4"></div>
+  <table class="table table-sm table-bordered">
     <tbody>
-        <tr class="table-primary"><th colspan="2">Infographic <span class="badge badge-primary float-right">Class</span></th></tr>
-        <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/Infographic">http://purl.org/cg/terms/Infographic</a></td></tr>
-        <tr><td class="theme-label">Definition</td><td>Infographics (a clipped compound of information and graphics) are graphic visual representations of information, data or knowledge intended to present information quickly and clearly.They can improve cognition by utilising graphics to enhance the human visual system's ability to see patterns and trends.</td></tr>
-        <tr><td class="theme-label">Comments</td><td>MARLO</td></tr>
-        <tr><td class="theme-label">Examples</td><td></td></tr>
+      <tr class="table-primary">
+        <th colspan="2">Infographic <span class="badge badge-primary float-right">Class</span></th>
+      </tr>
+      <tr>
+        <td class="theme-label">Identifier</td>
+        <td>
+          <a href="http://purl.org/cg/terms/Infographic">http://purl.org/cg/terms/Infographic</a>
+        </td>
+      </tr>
+      <tr>
+        <td class="theme-label">Definition</td>
+        <td>Infographics (a clipped compound of information and graphics) are graphic visual representations of information, data or knowledge intended to present information quickly and clearly.They can improve cognition by utilising graphics to enhance the human visual system's ability to see patterns and trends.</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Comments</td>
+        <td>MARLO</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Examples</td>
+        <td></td>
+      </tr>
     </tbody>
-</table>
-
-<h2 id="newspaper">Newspaper</h2>
-
-<div class="my-4">
-    </div>
-
-<table class="table table-sm table-bordered">
+  </table>
+  <h2 id="newspaper">Newspaper</h2>
+  <div class="my-4"></div>
+  <table class="table table-sm table-bordered">
     <tbody>
-        <tr class="table-primary"><th colspan="2">Newspaper <span class="badge badge-primary float-right">Class</span></th></tr>
-        <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/Newspaper">http://purl.org/cg/terms/Newspaper</a></td></tr>
-        <tr><td class="theme-label">Definition</td><td>A non-peer reviewed periodical, usually published daily or weekly, consisting primarily of editorials and news items concerning current or recent events and matters of public interest.</td></tr>
-        <tr><td class="theme-label">Comments</td><td>FaBiO</td></tr>
-        <tr><td class="theme-label">Examples</td><td></td></tr>
+      <tr class="table-primary">
+        <th colspan="2">Newspaper <span class="badge badge-primary float-right">Class</span></th>
+      </tr>
+      <tr>
+        <td class="theme-label">Identifier</td>
+        <td>
+          <a href="http://purl.org/cg/terms/Newspaper">http://purl.org/cg/terms/Newspaper</a>
+        </td>
+      </tr>
+      <tr>
+        <td class="theme-label">Definition</td>
+        <td>A non-peer reviewed periodical, usually published daily or weekly, consisting primarily of editorials and news items concerning current or recent events and matters of public interest.</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Comments</td>
+        <td>FaBiO</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Examples</td>
+        <td></td>
+      </tr>
     </tbody>
-</table>
-
-<h2 id="researchreport">Research Report</h2>
-
-<div class="my-4">
-    </div>
-
-<table class="table table-sm table-bordered">
+  </table>
+  <h2 id="researchreport">Research Report</h2>
+  <div class="my-4"></div>
+  <table class="table table-sm table-bordered">
     <tbody>
-        <tr class="table-primary"><th colspan="2">Research Report <span class="badge badge-primary float-right">Class</span></th></tr>
-        <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/Research_Report">http://purl.org/cg/terms/Research_Report</a></td></tr>
-        <tr><td class="theme-label">Definition</td><td>Reports disseminating the outcomes and deliverables of a research contract.</td></tr>
-        <tr><td class="theme-label">Comments</td><td>DataCite</td></tr>
-        <tr><td class="theme-label">Examples</td><td></td></tr>
+      <tr class="table-primary">
+        <th colspan="2">Research Report <span class="badge badge-primary float-right">Class</span></th>
+      </tr>
+      <tr>
+        <td class="theme-label">Identifier</td>
+        <td>
+          <a href="http://purl.org/cg/terms/Research_Report">http://purl.org/cg/terms/Research_Report</a>
+        </td>
+      </tr>
+      <tr>
+        <td class="theme-label">Definition</td>
+        <td>Reports disseminating the outcomes and deliverables of a research contract.</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Comments</td>
+        <td>DataCite</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Examples</td>
+        <td></td>
+      </tr>
     </tbody>
-</table>
-
-<h2 id="book">Book</h2>
-
-<div class="my-4">
-    </div>
-
-<table class="table table-sm table-bordered">
+  </table>
+  <h2 id="book">Book</h2>
+  <div class="my-4"></div>
+  <table class="table table-sm table-bordered">
     <tbody>
-        <tr class="table-primary"><th colspan="2">Book <span class="badge badge-primary float-right">Class</span></th></tr>
-        <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/Book">http://purl.org/cg/terms/Book</a></td></tr>
-        <tr><td class="theme-label">Definition</td><td>A non-serial document that is complete in one volume or a designated finite number of volumes. A book published by a publisher is usually identified by an International Standard Book Number (ISBN), and may be manifested as a physical printed publication on paper bound in a hard or soft cover, or in electronic format as an e-book.</td></tr>
-        <tr><td class="theme-label">Comments</td><td>FaBiO</td></tr>
-        <tr><td class="theme-label">Examples</td><td></td></tr>
+      <tr class="table-primary">
+        <th colspan="2">Book <span class="badge badge-primary float-right">Class</span></th>
+      </tr>
+      <tr>
+        <td class="theme-label">Identifier</td>
+        <td>
+          <a href="http://purl.org/cg/terms/Book">http://purl.org/cg/terms/Book</a>
+        </td>
+      </tr>
+      <tr>
+        <td class="theme-label">Definition</td>
+        <td>A non-serial document that is complete in one volume or a designated finite number of volumes. A book published by a publisher is usually identified by an International Standard Book Number (ISBN), and may be manifested as a physical printed publication on paper bound in a hard or soft cover, or in electronic format as an e-book.</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Comments</td>
+        <td>FaBiO</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Examples</td>
+        <td></td>
+      </tr>
     </tbody>
-</table>
-
-<h2 id="bookchapter">Book Chapter</h2>
-
-<div class="my-4">
-    </div>
-
-<table class="table table-sm table-bordered">
+  </table>
+  <h2 id="bookchapter">Book Chapter</h2>
+  <div class="my-4"></div>
+  <table class="table table-sm table-bordered">
     <tbody>
-        <tr class="table-primary"><th colspan="2">Book Chapter <span class="badge badge-primary float-right">Class</span></th></tr>
-        <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/Book_Chapter">http://purl.org/cg/terms/Book_Chapter</a></td></tr>
-        <tr><td class="theme-label">Definition</td><td>A defined chapter or section of a book, usually with a separate title or number.</td></tr>
-        <tr><td class="theme-label">Comments</td><td>COAR</td></tr>
-        <tr><td class="theme-label">Examples</td><td></td></tr>
+      <tr class="table-primary">
+        <th colspan="2">Book Chapter <span class="badge badge-primary float-right">Class</span></th>
+      </tr>
+      <tr>
+        <td class="theme-label">Identifier</td>
+        <td>
+          <a href="http://purl.org/cg/terms/Book_Chapter">http://purl.org/cg/terms/Book_Chapter</a>
+        </td>
+      </tr>
+      <tr>
+        <td class="theme-label">Definition</td>
+        <td>A defined chapter or section of a book, usually with a separate title or number.</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Comments</td>
+        <td>COAR</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Examples</td>
+        <td></td>
+      </tr>
     </tbody>
-</table>
-
-<h2 id="conferencepaper">Conference Paper</h2>
-
-<div class="my-4">
-    </div>
-
-<table class="table table-sm table-bordered">
+  </table>
+  <h2 id="conferencepaper">Conference Paper</h2>
+  <div class="my-4"></div>
+  <table class="table table-sm table-bordered">
     <tbody>
-        <tr class="table-primary"><th colspan="2">Conference Paper <span class="badge badge-primary float-right">Class</span></th></tr>
-        <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/Conference_Paper">http://purl.org/cg/terms/Conference_Paper</a></td></tr>
-        <tr><td class="theme-label">Definition</td><td>A paper, typically the realisation of a research paper reporting original research findings, usually published within a conference proceedings volume.</td></tr>
-        <tr><td class="theme-label">Comments</td><td>FaBiO</td></tr>
-        <tr><td class="theme-label">Examples</td><td></td></tr>
+      <tr class="table-primary">
+        <th colspan="2">Conference Paper <span class="badge badge-primary float-right">Class</span></th>
+      </tr>
+      <tr>
+        <td class="theme-label">Identifier</td>
+        <td>
+          <a href="http://purl.org/cg/terms/Conference_Paper">http://purl.org/cg/terms/Conference_Paper</a>
+        </td>
+      </tr>
+      <tr>
+        <td class="theme-label">Definition</td>
+        <td>A paper, typically the realisation of a research paper reporting original research findings, usually published within a conference proceedings volume.</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Comments</td>
+        <td>FaBiO</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Examples</td>
+        <td></td>
+      </tr>
     </tbody>
-</table>
-
-<h2 id="conferenceproceedings">Conference Proceedings</h2>
-
-<div class="my-4">
-    </div>
-
-<table class="table table-sm table-bordered">
+  </table>
+  <h2 id="conferenceproceedings">Conference Proceedings</h2>
+  <div class="my-4"></div>
+  <table class="table table-sm table-bordered">
     <tbody>
-        <tr class="table-primary"><th colspan="2">Conference Proceedings <span class="badge badge-primary float-right">Class</span></th></tr>
-        <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/Conference_Proceedings">http://purl.org/cg/terms/Conference_Proceedings</a></td></tr>
-        <tr><td class="theme-label">Definition</td><td>A document containing the programme and collected conference papers, or their abstracts, presented at a conference, seminar, symposium or similar event.</td></tr>
-        <tr><td class="theme-label">Comments</td><td>FaBiO</td></tr>
-        <tr><td class="theme-label">Examples</td><td></td></tr>
+      <tr class="table-primary">
+        <th colspan="2">Conference Proceedings <span class="badge badge-primary float-right">Class</span></th>
+      </tr>
+      <tr>
+        <td class="theme-label">Identifier</td>
+        <td>
+          <a href="http://purl.org/cg/terms/Conference_Proceedings">http://purl.org/cg/terms/Conference_Proceedings</a>
+        </td>
+      </tr>
+      <tr>
+        <td class="theme-label">Definition</td>
+        <td>A document containing the programme and collected conference papers, or their abstracts, presented at a conference, seminar, symposium or similar event.</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Comments</td>
+        <td>FaBiO</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Examples</td>
+        <td></td>
+      </tr>
     </tbody>
-</table>
-
-<h2 id="magazinearticle">Magazine Article</h2>
-
-<div class="my-4">
-    </div>
-
-<table class="table table-sm table-bordered">
+  </table>
+  <h2 id="magazinearticle">Magazine Article</h2>
+  <div class="my-4"></div>
+  <table class="table table-sm table-bordered">
     <tbody>
-        <tr class="table-primary"><th colspan="2">Magazine Article <span class="badge badge-primary float-right">Class</span></th></tr>
-        <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/Magazine_Article">http://purl.org/cg/terms/Magazine_Article</a></td></tr>
-        <tr><td class="theme-label">Definition</td><td>An article published in a magazine issue.</td></tr>
-        <tr><td class="theme-label">Comments</td><td>FaBiO</td></tr>
-        <tr><td class="theme-label">Examples</td><td></td></tr>
+      <tr class="table-primary">
+        <th colspan="2">Magazine Article <span class="badge badge-primary float-right">Class</span></th>
+      </tr>
+      <tr>
+        <td class="theme-label">Identifier</td>
+        <td>
+          <a href="http://purl.org/cg/terms/Magazine_Article">http://purl.org/cg/terms/Magazine_Article</a>
+        </td>
+      </tr>
+      <tr>
+        <td class="theme-label">Definition</td>
+        <td>An article published in a magazine issue.</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Comments</td>
+        <td>FaBiO</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Examples</td>
+        <td></td>
+      </tr>
     </tbody>
-</table>
-
-<h2 id="personalcommunication">Personal Communication</h2>
-
-<div class="my-4">
-    </div>
-
-<table class="table table-sm table-bordered">
+  </table>
+  <h2 id="personalcommunication">Personal Communication</h2>
+  <div class="my-4"></div>
+  <table class="table table-sm table-bordered">
     <tbody>
-        <tr class="table-primary"><th colspan="2">Personal Communication <span class="badge badge-primary float-right">Class</span></th></tr>
-        <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/Personal_Communication">http://purl.org/cg/terms/Personal_Communication</a></td></tr>
-        <tr><td class="theme-label">Definition</td><td>Information communicated personally by verbal or written means from one individual to one or more another persons or organisations.</td></tr>
-        <tr><td class="theme-label">Comments</td><td>FabiO</td></tr>
-        <tr><td class="theme-label">Examples</td><td></td></tr>
+      <tr class="table-primary">
+        <th colspan="2">Personal Communication <span class="badge badge-primary float-right">Class</span></th>
+      </tr>
+      <tr>
+        <td class="theme-label">Identifier</td>
+        <td>
+          <a href="http://purl.org/cg/terms/Personal_Communication">http://purl.org/cg/terms/Personal_Communication</a>
+        </td>
+      </tr>
+      <tr>
+        <td class="theme-label">Definition</td>
+        <td>Information communicated personally by verbal or written means from one individual to one or more another persons or organisations.</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Comments</td>
+        <td>FabiO</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Examples</td>
+        <td></td>
+      </tr>
     </tbody>
-</table>
-
-<h2 id="financialreport">Financial Report</h2>
-
-<div class="my-4">
-    </div>
-
-<table class="table table-sm table-bordered">
+  </table>
+  <h2 id="financialreport">Financial Report</h2>
+  <div class="my-4"></div>
+  <table class="table table-sm table-bordered">
     <tbody>
-        <tr class="table-primary"><th colspan="2">Financial Report <span class="badge badge-primary float-right">Class</span></th></tr>
-        <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/Financial_Report">http://purl.org/cg/terms/Financial_Report</a></td></tr>
-        <tr><td class="theme-label">Definition</td><td>??</td></tr>
-        <tr><td class="theme-label">Comments</td><td>??</td></tr>
-        <tr><td class="theme-label">Examples</td><td></td></tr>
+      <tr class="table-primary">
+        <th colspan="2">Financial Report <span class="badge badge-primary float-right">Class</span></th>
+      </tr>
+      <tr>
+        <td class="theme-label">Identifier</td>
+        <td>
+          <a href="http://purl.org/cg/terms/Financial_Report">http://purl.org/cg/terms/Financial_Report</a>
+        </td>
+      </tr>
+      <tr>
+        <td class="theme-label">Definition</td>
+        <td>??</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Comments</td>
+        <td>??</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Examples</td>
+        <td></td>
+      </tr>
     </tbody>
-</table>
-
-<h2 id="presentation">Presentation</h2>
-
-<div class="my-4">
-    </div>
-
-<table class="table table-sm table-bordered">
+  </table>
+  <h2 id="presentation">Presentation</h2>
+  <div class="my-4"></div>
+  <table class="table table-sm table-bordered">
     <tbody>
-        <tr class="table-primary"><th colspan="2">Presentation <span class="badge badge-primary float-right">Class</span></th></tr>
-        <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/Presentation">http://purl.org/cg/terms/Presentation</a></td></tr>
-        <tr><td class="theme-label">Definition</td><td>A set of slides containing text, tables or figures, designed to communicate ideas or research results, for projection and viewing by an audience at a conference, symposium, seminar, lecture, workshop or other gatherings, typically embodied in a particular manifestation format such as a SlideShare or PowerPoint slideshow.</td></tr>
-        <tr><td class="theme-label">Comments</td><td>FaBiO</td></tr>
-        <tr><td class="theme-label">Examples</td><td></td></tr>
+      <tr class="table-primary">
+        <th colspan="2">Presentation <span class="badge badge-primary float-right">Class</span></th>
+      </tr>
+      <tr>
+        <td class="theme-label">Identifier</td>
+        <td>
+          <a href="http://purl.org/cg/terms/Presentation">http://purl.org/cg/terms/Presentation</a>
+        </td>
+      </tr>
+      <tr>
+        <td class="theme-label">Definition</td>
+        <td>A set of slides containing text, tables or figures, designed to communicate ideas or research results, for projection and viewing by an audience at a conference, symposium, seminar, lecture, workshop or other gatherings, typically embodied in a particular manifestation format such as a SlideShare or PowerPoint slideshow.</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Comments</td>
+        <td>FaBiO</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Examples</td>
+        <td></td>
+      </tr>
     </tbody>
-</table>
-
-<h2 id="thesis">Thesis</h2>
-
-<div class="my-4">
-    </div>
-
-<table class="table table-sm table-bordered">
+  </table>
+  <h2 id="thesis">Thesis</h2>
+  <div class="my-4"></div>
+  <table class="table table-sm table-bordered">
     <tbody>
-        <tr class="table-primary"><th colspan="2">Thesis <span class="badge badge-primary float-right">Class</span></th></tr>
-        <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/Thesis">http://purl.org/cg/terms/Thesis</a></td></tr>
-        <tr><td class="theme-label">Definition</td><td>A thesis or dissertation is a document submitted in support of candidature for an academic degree or professional qualification presenting the author's research and findings.</td></tr>
-        <tr><td class="theme-label">Comments</td><td>COAR</td></tr>
-        <tr><td class="theme-label">Examples</td><td></td></tr>
+      <tr class="table-primary">
+        <th colspan="2">Thesis <span class="badge badge-primary float-right">Class</span></th>
+      </tr>
+      <tr>
+        <td class="theme-label">Identifier</td>
+        <td>
+          <a href="http://purl.org/cg/terms/Thesis">http://purl.org/cg/terms/Thesis</a>
+        </td>
+      </tr>
+      <tr>
+        <td class="theme-label">Definition</td>
+        <td>A thesis or dissertation is a document submitted in support of candidature for an academic degree or professional qualification presenting the author's research and findings.</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Comments</td>
+        <td>COAR</td>
+      </tr>
+      <tr>
+        <td class="theme-label">Examples</td>
+        <td></td>
+      </tr>
     </tbody>
-</table>
-
-    </body>
+  </table>
+</body>
 </html>

--- a/cgcore.html
+++ b/cgcore.html
@@ -1,855 +1,1564 @@
 <!DOCTYPE html>
 <html>
-    <head>
-        <meta charset="utf-8">
-        <title>CG Core metadata schema</title>
-        <link rel="stylesheet" href="main.css">
-        <style>
+<head>
+  <meta name="generator" content="HTML Tidy for HTML5 for Linux version 5.7.16">
+  <meta charset="utf-8">
+  <title>CG Core metadata schema</title>
+  <link rel="stylesheet" href="main.css">
+  <style>
             table {
             }
             .table .table-sm .table-bordered {
                 color: #333;;
             }
 
-        </style>
-
-    </head>
-    <body>
-        <div>
-             <hr />
-            <div id="titleP">
-                <h1 id="cgcoremetadatareferenceguide">CG Core metadata reference guide</h1>
-                <p>This page provides a list of the metadata elements that are used in the CG Core metadata schema. The CG Core metadata schema is an application profile and is built from existing standards as much as possible. It is an effort led by the Big Data Platform Metadata Working Group of the CGIAR.</p>
-                <p>The CG Core aims at describing all types of information products that are published by the different CGIAR centres. There are many benefits of having a clear and harmonised way to describe information products:</p>
-                <ul>
-                    <li>better interoperability</li>
-                    <li>better transparency</li>
-                    <li>easy monitoring</li>
-                </ul>
-                <p>This document provides guidelines on how to use the CG Core metadata schema and provides examples on how to use it. A RDF version of the application profile will be available soon.</p>
-            </div>
-            <div class="my">
-                    <h3>Quick jump</h3>
-                    <a class="btn btn-sm btn-outline-secondary m-0" href="#informationproduct">Information product</a>
-                    <a class="btn btn-sm btn-outline-secondary m-0" href="#Creator">Creator</a>
-                    <a class="btn btn-sm btn-outline-secondary m-0" href="#Contributor">Contributor</a>
-                    <a class="btn btn-sm btn-outline-secondary m-0" href="#Coverage">Coverage</a>
-                    <a class="btn btn-sm btn-outline-secondary m-0" href="#scientificpublication">Scientific Publication</a>
-                    <a class="btn btn-sm btn-outline-secondary m-0" href="#concept">Concept</a>
-            </div>
-
-            <h2 id="informationproduct">Information product</h2>
-
-            <div class="my-4">
-                    <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:identfier">identifier</a>
-                    <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:title">title</a>
-                    <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:description">description</a>
-                    <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:type">type</a>
-                    <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:language">language</a>
-                    <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:license">license</a>
-                    <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:rightsHolder">rightsHolder</a>
-                    <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:accessRights">accessRights</a>
-                    <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:subject">subject</a>
-                    <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:issued">issued</a>
-                    <a class="btn btn-sm btn-outline-secondary m-1" href="#cg:embargoDate">embargoDate</a>
-                    <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:creator">creator</a>
-                    <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:contributor">contributor</a>
-                    <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:coverage">coverage</a>
-                    <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:relation">relation</a>
-                    <a class="btn btn-sm btn-outline-secondary m-1" href="#cg:HasMetadata">hasMetadata</a>
-                </div>
-
-            <p class="invisible">
-                <a id="dcterms:identifier"></a><a id="identifier"></a></p>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-secondary"><th colspan="2">identifier <span class="badge badge-secondary float-right">Property</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/dc/terms/identifier">http://purl.org/dc/terms/identifier</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>An unambiguous reference to the resource within a given context.</td></tr>
-                    <tr><td class="theme-label">Comments</td><td>Recommended best practice is to identify the resource by using a DOI or an handle</td></tr>
-                    <tr><td class="theme-label">Examples</td><td></td></tr>
-                </tbody>
-            </table>
-
-            <p class="invisible">
-                <a id="dcterms:title"></a><a id="title"></a></p>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-secondary"><th colspan="2">title <span class="badge badge-secondary float-right">Property</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/dc/terms/title">http://purl.org/dc/terms/title</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>A name given to the resource</td></tr>
-                    <tr><td class="theme-label">Comments</td><td>Follow standard title formatting for capitalization and punctuation.</td></tr>
-                    <tr><td class="theme-label">Examples</td><td><code>'Managing for timber and biodiversity in the Congo basin' -- 'A 2007 Social Accounting Matrix for China' -- '2012 Global Hunger Index Data'</code></td></tr>
-                </tbody>
-            </table>
-
-            <p class="invisible">
-                <a id="dcterms:description"></a><a id="description"></a></p>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-secondary"><th colspan="2">description <span class="badge badge-secondary float-right">Property</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/dc/terms/description">http://purl.org/dc/terms/description</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>Description may include but is not limited to: an abstract, a table of contents, a graphical representation, or a free-text account of the resource.</td></tr>
-                    <tr><td class="theme-label">Comments</td><td>Descriptive details significantly improve discoverability via search engines such as Google and Bing, and will aid interlink between related resources at the meta-search/indexer level.
-            Descriptions can be provided in multiple languages if appropriate and available. </td></tr>
-                    <tr><td class="theme-label">Examples</td><td></td></tr>
-                </tbody>
-            </table>
-
-            <p class="invisible">
-                <a id="dcterms:type"></a><a id="type"></a></p>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-secondary"><th colspan="2">type <span class="badge badge-secondary float-right">Property</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/dc/terms/type">http://purl.org/dc/terms/type</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>The nature or genre of the resource</td></tr>
-                    <tr><td class="theme-label">Comments</td><td>Must be populated with a value from the local <a href="IPtypes.html">Type</a> and subType lists</td></tr>
-                    <tr><td class="theme-label">Examples</td><td><code>Datafile</code></td></tr>
-                </tbody>
-            </table>
-
-            <p class="invisible">
-                <a id="dcterms:language"></a><a id="language"></a></p>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-secondary"><th colspan="2">language <span class="badge badge-secondary float-right">Property</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/dc/terms/language">http://purl.org/dc/terms/language</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>A language of the resource.</td></tr>
-                    <tr><td class="theme-label">Comments</td><td>ISO 639-2 (alpha-3)</td></tr>
-                    <tr><td class="theme-label">Examples</td><td><code>eng</code></td></tr>
-                </tbody>
-            </table>
-
-            <p class="invisible">
-                <a id="dcterms:license"></a><a id="license"></a></p>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-secondary"><th colspan="2">license <span class="badge badge-secondary float-right">Property</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/dc/terms/license">http://purl.org/dc/terms/license</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>A legal document giving official permission to do something with the resource.</td></tr>
-                    <tr><td class="theme-label">Comments</td><td>List of licenses from <a href="https://spdx.org/licenses/">SPDX</a></td></tr>
-                    <tr><td class="theme-label">Examples</td><td> <code><a href="http://creativecommons.org/licenses/by/4.0/legalcode">http://creativecommons.org/licenses/by/4.0/legalcode</a></code></td></tr>
-                </tbody>
-            </table>
-
-            <p class="invisible">
-                <a id="dcterms:rightsHolder"></a><a id="rightsHolder"></a></p>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-secondary"><th colspan="2">rightsHolder <span class="badge badge-secondary float-right">Property</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/dc/terms/rightsHolder">http://purl.org/dc/terms/rightsHolder</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>A person or organisation owning or managing rights over the resource.</td></tr>
-                    <tr><td class="theme-label">Comments</td><td></td></tr>
-                    <tr><td class="theme-label">Examples</td><td><code>CIAT</code></td></tr>
-                </tbody>
-            </table>
-
-            <p class="invisible">
-                <a id="dcterms:accessRights"></a><a id="accessRights"></a></p>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-secondary"><th colspan="2">accessRights <span class="badge badge-secondary float-right">Property</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/dc/terms/accessRights">http://purl.org/dc/terms/accessRights</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>Information about who can access the resource or an indication of its security status. Access Rights may include information regarding access or restrictions based on privacy, security, or other policies.</td></tr>
-                    <tr><td class="theme-label">Comments</td><td>Values should come from the following list: "open", "restricted"</td></tr>
-                    <tr><td class="theme-label">Examples</td><td><code>open</code></td></tr>
-                </tbody>
-            </table>
-
-            <p class="invisible">
-                <a id="dcterms:subject"></a><a id="subject"></a></p>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-secondary"><th colspan="2">subject <span class="badge badge-secondary float-right">Property</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/dc/terms/subject">http://purl.org/dc/terms/subject</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>keywords describing the subject of the information product.</td></tr>
-                    <tr><td class="theme-label">Comments</td><td>To be used to link the resource to one or more concept</td></tr>
-                    <tr><td class="theme-label">Examples</td><td></td></tr>
-                </tbody>
-            </table>
-
-            <p class="invisible">
-                <a id="dcterms:issued"></a><a id="issued"></a></p>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-secondary"><th colspan="2">issued <span class="badge badge-secondary float-right">Property</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/dc/terms/issued">http://purl.org/dc/terms/issued</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>Date of formal issuance (e.g., publication) of the resource</td></tr>
-                    <tr><td class="theme-label">Comments</td><td>The date when the information product was created in its final form to be published</td></tr>
-                    <tr><td class="theme-label">Examples</td><td></td></tr>
-                </tbody>
-            </table>
-
-            <p class="invisible">
-                <a id="cg:embargoDate"></a><a id="embargoDate"></a></p>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-secondary"><th colspan="2">embargoDate <span class="badge badge-secondary float-right">Property</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/embargoDate">http://purl.org/cg/terms/embargoDate</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>In cases when the information product has an embargo this date indicates when it would be available.</td></tr>
-                    <tr><td class="theme-label">Comments</td><td></td></tr>
-                    <tr><td class="theme-label">Examples</td><td></td></tr>
-                </tbody>
-            </table>
-
-            <p class="invisible">
-                <a id="dcterms:creator"></a><a id="creator"></a></p>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-secondary"><th colspan="2">creator <span class="badge badge-secondary float-right">Property</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/dc/terms/creator">http://purl.org/dc/terms/creator</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>To be used to link the resource to one or more creator objects</td></tr>
-                    <tr><td class="theme-label">Comments</td><td>This term is intended to be used with non-literal values</td></tr>
-                    <tr><td class="theme-label">Examples</td><td></td></tr>
-                </tbody>
-            </table>
-
-            <p class="invisible">
-                <a id="dcterms:contributor"></a><a id="contributor"></a></p>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-secondary"><th colspan="2">contributor <span class="badge badge-secondary float-right">Property</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/dc/terms/contributor">http://purl.org/dc/terms/contributor</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>To be used to link the resource to one or more contributor objects</td></tr>
-                    <tr><td class="theme-label">Comments</td><td>This term is intended to be used with non-literal values</td></tr>
-                    <tr><td class="theme-label">Examples</td><td></td></tr>
-                </tbody>
-            </table>
-
-            <p class="invisible">
-                <a id="dcterms:coverage"></a><a id="coverage"></a></p>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-secondary"><th colspan="2">coverage <span class="badge badge-secondary float-right">Property</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/dc/terms/coverage">http://purl.org/dc/terms/coverage</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>To be used to link the resource to one or more coverage objects</td></tr>
-                    <tr><td class="theme-label">Comments</td><td>This term is intended to be used with non-literal values</td></tr>
-                    <tr><td class="theme-label">Examples</td><td></td></tr>
-                </tbody>
-            </table>
-
-            <p class="invisible">
-                <a id="dcterms:relation"></a><a id="relation"></a></p>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-secondary"><th colspan="2">relation <span class="badge badge-secondary float-right">Property</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/dc/terms/relation">http://purl.org/dc/terms/relation</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>A related resource</td></tr>
-                    <tr><td class="theme-label">Comments</td><td>This term is intended to be used with non-literal values. Should be use to link a dataset to its related publication(s) and reciprocally</td></tr>
-                    <tr><td class="theme-label">Examples</td><td></td></tr>
-                </tbody>
-            </table>
-
-            <p class="invisible">
-                <a id="cg:HasMetadata"></a><a id="HasMetadata"></a></p>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-secondary"><th colspan="2">hasMetadata <span class="badge badge-secondary float-right">Property</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/hasMetadata">http://purl.org/cg/terms/hasMetadata</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>A related resource that is the metadata record for the measured variables of the described dataset</td></tr>
-                    <tr><td class="theme-label">Comments</td><td>This term is intended to be used with non-literal values.</td></tr>
-                    <tr><td class="theme-label">Examples</td><td></td></tr>
-                </tbody>
-            </table>
-
-            <h2 id="Creator">Creator</h2>
-
-            <div class="my-4">
-                    <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:identifier">identifier</a>
-                    <a class="btn btn-sm btn-outline-secondary m-1" href="#cg:affiliation">affiliation</a>
-                    <a class="btn btn-sm btn-outline-secondary m-1" href="#cg:creator name">name</a>
-                </div>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-primary"><th colspan="2">Creator <span class="badge badge-primary float-right">Class</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/Creator">http://purl.org/cg/terms/Creator</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>The author(s), researcher(s), scientist(s) responsible for producing the information product</td></tr>
-                    <tr><td class="theme-label">Comments</td><td></td></tr>
-                    <tr><td class="theme-label">Examples</td><td></td></tr>
-                </tbody>
-            </table>
-
-            <p class="invisible">
-                <a id="dcterms:identifier"></a><a id="identifer"></a></p>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-secondary"><th colspan="2">identifier <span class="badge badge-secondary float-right">Property</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/dc/terms/identifier">http://purl.org/dc/terms/identifier</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>ORCID</td></tr>
-                    <tr><td class="theme-label">Comments</td><td></td></tr>
-                    <tr><td class="theme-label">Examples</td><td></td></tr>
-                </tbody>
-            </table>
-
-            <p class="invisible">
-                <a id="cg:affiliation"></a><a id="affiliation"></a></p>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-secondary"><th colspan="2">affiliation <span class="badge badge-secondary float-right">Property</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/affiliation">http://purl.org/cg/terms/affiliation</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>the affiliation of the creator</td></tr>
-                    <tr><td class="theme-label">Comments</td><td>Must be populated with a value coming from the CLARISA <a href="https://clarisa.cgiar.org/api/institutions">institution list</a> or the <a href="https://www.grid.ac/">grid</a> list</td></tr>
-                    <tr><td class="theme-label">Examples</td><td><code>Bioversity International</code></td></tr>
-                </tbody>
-            </table>
-
-            <p class="invisible">
-                <a id="cg:creator name"></a><a id="name"></a></p>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-secondary"><th colspan="2">name <span class="badge badge-secondary float-right">Property</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://xmlns.com/foaf/0.1/name">http://xmlns.com/foaf/0.1/name</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>The full name identifying the creator</td></tr>
-                    <tr><td class="theme-label">Comments</td><td></td></tr>
-                    <tr><td class="theme-label">Examples</td><td></td></tr>
-                </tbody>
-            </table>
-
-            <h2 id="Contributor">Contributor</h2>
-
-            <div class="my-4">
-                    <a class="btn btn-sm btn-outline-secondary m-1" href="#cg:contributor name">contributor name</a>
-                    <a class="btn btn-sm btn-outline-secondary m-1" href="#cg:contributor type">type</a>
-                </div>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-primary"><th colspan="2">Contributor <span class="badge badge-primary float-right">Class</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/Contributor">http://purl.org/cg/terms/Contributor</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>Organisation, or service making contributions to the information product.</td></tr>
-                    <tr><td class="theme-label">Comments</td><td>describe one of the following: "Project", "Project Lead Entity", "Partner", "CRP", "Donor"</td></tr>
-                    <tr><td class="theme-label">Examples</td><td></td></tr>
-                </tbody>
-            </table>
-
-            <p class="invisible">
-                <a id="cg:contributor name"></a><a id="name"></a></p>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-secondary"><th colspan="2">name <span class="badge badge-secondary float-right">Property</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://xmlns.com/foaf/0.1/name">http://xmlns.com/foaf/0.1/name</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>The name identifying the contributor</td></tr>
-                    <tr><td class="theme-label">Comments</td><td><ul><li>for donors, recommendation to use <a href="https://www.crossref.org/services/funder-registry/"> crossref Donors registry</a></li>
-                    <li>for CRPs and Project Lead Entity, recommendation to use <a href="https://clarisa.cgiar.org/api/cgiar-entities">CLARISA entity list</a></li>
-                    <li>for partners, recommendation to use <a href="https://clarisa.cgiar.org/api/institutions">CLARISA institution list</a> </li>
-                    </ul>
-                    </td></tr>
-                    <tr><td class="theme-label">Examples</td><td></td></tr>
-                </tbody>
-            </table>
-
-            <p class="invisible">
-                <a id="cg:contributor type"></a><a id="type"></a></p>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-secondary"><th colspan="2">type<span class="badge badge-secondary float-right">Property</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/dc/terms/type">http://purl.org/dc/terms/type</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>The type of contributor the contributor</td></tr>
-                    <tr><td class="theme-label">Comments</td><td>one of these values: "Project", "Project Lead Entity", "Partner", "CRP", "Donor"</td></tr>
-                    <tr><td class="theme-label">Examples</td><td></td></tr>
-                </tbody>
-            </table>
-
-            <h2 id="Coverage">Coverage</h2>
-
-            <div class="my-4">
-                    <a class="btn btn-sm btn-outline-secondary m-1" href="#cgcoverage type">type</a>
-                    <a class="btn btn-sm btn-outline-secondary m-1" href="#spatial">spatial coverage</a>
-                    <a class="btn btn-sm btn-outline-secondary m-1" href="#temporal">temporal coverage</a>
-                    <a class="btn btn-sm btn-outline-secondary m-1" href="#label">label</a>
-                    <a class="btn btn-sm btn-outline-secondary m-1" href="#cgcoverage identifier">identifier</a>
-                    <a class="btn btn-sm btn-outline-secondary m-1" href="#cg:code">code</a>
-                    <a class="btn btn-sm btn-outline-secondary m-1" href="#cg:xCoord">xCoord</a>
-                    <a class="btn btn-sm btn-outline-secondary m-1" href="#cg:yCoord">yCoord</a>
-                </div>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-primary"><th colspan="2">Coverage <span class="badge badge-primary float-right">Class</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/coverage">http://purl.org/cg/terms/coverage</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>Spatial or temporal coverage</td></tr>
-                    <tr><td class="theme-label">Comments</td><td></td></tr>
-                    <tr><td class="theme-label">Examples</td><td></td></tr>
-                </tbody>
-            </table>
-
-            <p class="invisible">
-                <a id="cgcoverage type"></a><a id="type"></a></p>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-secondary"><th colspan="2">type <span class="badge badge-secondary float-right">Property</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/dc/terms/type">http://purl.org/dc/terms/type</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>The nature or genre of the coverage information</td></tr>
-                    <tr><td class="theme-label">Comments</td><td>Must be populated with a value coming from the Coverage type list</td></tr>
-                    <tr><td class="theme-label">Examples</td><td><code>"Spatial", "Temporal," "Region", "Country", "Administrative Unit", "AEZ", "X", "Y"</code></td></tr>
-                </tbody>
-            </table>
-
-            <p class="invisible">
-                <a id="#spatial"></a><a id="spatial"></a></p>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-secondary"><th colspan="2">Spatial Coverage<span class="badge badge-secondary float-right">Property</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/dc/terms/spatial">http://purl.org/dc/terms/spatial</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>Spatial characteristics of the resource.</td></tr>
-                    <tr><td class="theme-label">Comments</td><td></td></tr>
-                    <tr><td class="theme-label">Examples</td><td></td></tr>
-                </tbody>
-            </table>
-
-            <p class="invisible">
-                <a id="#temporal"></a><a id="temporal"></a></p>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-secondary"><th colspan="2">Temporal Coverage <span class="badge badge-secondary float-right">Property</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/dc/terms/temportal">http://purl.org/dc/terms/temporal</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>Temporal characteristics of the resource.</td></tr>
-                    <tr><td class="theme-label">Comments</td><td>Should point to an interval of time that is named or defined by its start and end dates.</td></tr>
-                    <tr><td class="theme-label">Examples</td><td></td></tr>
-                </tbody>
-            </table>
-
-            <p class="invisible">
-                <a id="#label"></a><a id="label"></a></p>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-secondary"><th colspan="2">Label <span class="badge badge-secondary float-right">Property</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://www.w3.org/2000/01/rdf-schema#label">http://www.w3.org/2000/01/rdf-schema#label</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>Label of the spatial zone</td></tr>
-                    <tr><td class="theme-label">Comments</td><td></td></tr>
-                    <tr><td class="theme-label">Examples</td><td></td></tr>
-                </tbody>
-            </table>
-
-            <p class="invisible">
-                <a id="cgcoverage identifier"></a><a id="identifier"></a></p>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-secondary"><th colspan="2">Identifier<span class="badge badge-secondary float-right">Property</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="ttp://purl.org/dc/terms/identifier">http://purl.org/dc/terms/identifier</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>Identifier of the spatial unit</td></tr>
-                    <tr><td class="theme-label">Comments</td><td></td></tr>
-                    <tr><td class="theme-label">Examples</td><td></td></tr>
-                </tbody>
-            </table>
-
-            <p class="invisible">
-                <a id="#cg:code"></a><a id="code"></a></p>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-secondary"><th colspan="2">Code<span class="badge badge-secondary float-right">Property</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/code">http://purl.org/cg/terms/code</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>Code of the agroecological zone as defined by FAO</td></tr>
-                    <tr><td class="theme-label">Comments</td><td></td></tr>
-                    <tr><td class="theme-label">Examples</td><td><code>101</code></td></tr>
-                </tbody>
-            </table>
-
-            <p class="invisible">
-                <a id="#cg:xCoord"></a><a id="xCoord"></a></p>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-secondary"><th colspan="2">xCoord<span class="badge badge-secondary float-right">Property</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/xCoord">http://purl.org/cg/terms/xCoord</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>x coordinate, in decimal degrees</td></tr>
-                    <tr><td class="theme-label">Comments</td><td></td></tr>
-                    <tr><td class="theme-label">Examples</td><td></td></tr>
-                </tbody>
-            </table>
-
-            <p class="invisible">
-                <a id="#cg:yCoord"></a><a id="yCoord"></a></p>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-secondary"><th colspan="2">yCoord<span class="badge badge-secondary float-right">Property</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/yCoord">http://purl.org/cg/terms/yCoord</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>y coordinate, in decimal degrees</td></tr>
-                    <tr><td class="theme-label">Comments</td><td></td></tr>
-                    <tr><td class="theme-label">Examples</td><td></td></tr>
-                </tbody>
-            </table>
-
-            <h2 id="scientificpublication">Scientific Publication</h2>
-
-            <div class="my-4">
-                    <a class="btn btn-sm btn-outline-secondary m-1" href="#dct:abstract">abstract</a>
-                    <a class="btn btn-sm btn-outline-secondary m-1" href="#dct:bibliographicCitation">bibliographicCitation</a>
-                    <a class="btn btn-sm btn-outline-secondary m-1" href="#dct:publisher">publisher</a>
-                    <a class="btn btn-sm btn-outline-secondary m-1" href="#cg:issn">issn</a>
-                    <a class="btn btn-sm btn-outline-secondary m-1" href="#cg:isbn">isbn</a>
-                    <a class="btn btn-sm btn-outline-secondary m-1" href="#cg:peer-reviewed">peer-reviewed</a>
-                    <a class="btn btn-sm btn-outline-secondary m-1" href="#dct:alternative">alternative title</a>
-                    <a class="btn btn-sm btn-outline-secondary m-1" href="#cg:howpublished">howpublished</a>
-                    <a class="btn btn-sm btn-outline-secondary m-1" href="#cg:journal">journal</a>
-                    <a class="btn btn-sm btn-outline-secondary m-1" href="#cg:booktitle">booktitle</a>
-                    <a class="btn btn-sm btn-outline-secondary m-1" href="#cg:chapter">chapter</a>
-                    <a class="btn btn-sm btn-outline-secondary m-1" href="#cg:pages">pages</a>
-                    <a class="btn btn-sm btn-outline-secondary m-1" href="#cg:volume">volume</a>
-                    <a class="btn btn-sm btn-outline-secondary m-1" href="#cg:number">number</a>
-                    <a class="btn btn-sm btn-outline-secondary m-1" href="#dct:extent">extent</a>
-                    <a class="btn btn-sm btn-outline-secondary m-1" href="#cg:series">series</a>
-                    <a class="btn btn-sm btn-outline-secondary m-1" href="#cg:edition">edition</a>
-                    <a class="btn btn-sm btn-outline-secondary m-1" href="#cg:notes">notes</a>
-                    <a class="btn btn-sm btn-outline-secondary m-1" href="#dct:audience">audience</a>
-                    <a class="btn btn-sm btn-outline-secondary m-1" href="#dct:isPartOf">isPartOf</a>
-                </div>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-primary"><th colspan="2">Scientific Publication <span class="badge badge-primary float-right">Class</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/ScientificPublication">http://purl.org/cg/terms/ScientificPublication</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>Specific Information Product type covering publications</td></tr>
-                    <tr><td class="theme-label">Comments</td><td></td></tr>
-                    <tr><td class="theme-label">Examples</td><td></td></tr>
-                </tbody>
-            </table>
-
-            <p class="invisible">
-                <a id="dct:abstract"></a><a id="abstract"></a></p>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-secondary"><th colspan="2">abstract <span class="badge badge-secondary float-right">Property</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/dc/terms/abstract">http://purl.org/dc/terms/abstract</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>A summary of the resource</td></tr>
-                    <tr><td class="theme-label">Comments</td><td>refines <a href="http://purl.org/dc/terms/description">dct:description</a></td></tr>
-                    <tr><td class="theme-label">Examples</td><td></td></tr>
-                </tbody>
-            </table>
-
-            <p class="invisible">
-                <a id="dct:bibliographicCitation"></a><a id="bibliographicCitation"></a></p>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-secondary"><th colspan="2">bibliographicCitation <span class="badge badge-secondary float-right">Property</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/dc/terms/bibliographicCitation">http://purl.org/dc/terms/bibliographicCitation</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>A bibliographic reference for the resource</td></tr>
-                    <tr><td class="theme-label">Comments</td><td>Recommended practice is to include sufficient bibliographic detail to identify the resource as unambiguously as possible. Refines <a href="http://purl.org/dc/terms/identifier">dct:identifier</a></td></tr>
-                    <tr><td class="theme-label">Examples</td><td></td></tr>
-                </tbody>
-            </table>
-
-            <p class="invisible">
-                <a id="dct:publisher"></a><a id="publisher"></a></p>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-secondary"><th colspan="2">publisher<span class="badge badge-secondary float-right">Property</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/dc/terms/publisher">http://purl.org/dc/terms/publisher</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>An entity responsible for making the resource available</td></tr>
-                    <tr><td class="theme-label">Comments</td><td>Here, the publisher of the scientific publication</td></tr>
-                    <tr><td class="theme-label">Examples</td><td></td></tr>
-                </tbody>
-            </table>
-
-            <p class="invisible">
-                <a id="cg:issn"></a><a id="issn"></a></p>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-secondary"><th colspan="2">issn<span class="badge badge-secondary float-right">Property</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/issn">http://purl.org/cg/terms/issn</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>Used to record ISSN number</td></tr>
-                    <tr><td class="theme-label">Comments</td><td>Refines <a href="http://purl.org/dc/terms/identifier">dct:identifier</a></td></tr>
-                    <tr><td class="theme-label">Examples</td><td></td></tr>
-                </tbody>
-            </table>
-
-            <p class="invisible">
-                <a id="cg:isbn"></a><a id="isbn"></a></p>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-secondary"><th colspan="2">isbn<span class="badge badge-secondary float-right">Property</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/isbn">http://purl.org/cg/terms/isbn</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>Used to record ISBN number</td></tr>
-                    <tr><td class="theme-label">Comments</td><td>Refines <a href="http://purl.org/dc/terms/identifier">dct:identifier</a></td></tr>
-                    <tr><td class="theme-label">Examples</td><td></td></tr>
-                </tbody>
-            </table>
-
-            <p class="invisible">
-                <a id="cg:peer-reviewed"></a><a id="peer-reviewed"></a></p>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-secondary"><th colspan="2">peer-reviewed <span class="badge badge-secondary float-right">Property</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/peer-reviewed">http://purl.org/cg/terms/peer-reviewed</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>If the resource has been peer reviewed</td></tr>
-                    <tr><td class="theme-label">Comments</td><td></td></tr>
-                    <tr><td class="theme-label">Examples</td><td>true is peer-reviewed, not used if not</td></tr>
-                </tbody>
-            </table>
-
-            <p class="invisible">
-                <a id="dct:alternative"></a><a id="alternative"></a></p>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-secondary"><th colspan="2">Alternative Title<span class="badge badge-secondary float-right">Property</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/dc/terms/abstract">http://purl.org/dc/terms/alternative</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>An alternative name for the resource.</td></tr>
-                    <tr><td class="theme-label">Comments</td><td>refines <a href="http://purl.org/dc/terms/title">dct:title</a></td></tr>
-                    <tr><td class="theme-label">Examples</td><td></td></tr>
-                </tbody>
-            </table>
-
-            <p class="invisible">
-                <a id="cg:howpublished"></a><a id="howpublished"></a></p>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-secondary"><th colspan="2">howpublished <span class="badge badge-secondary float-right">Property</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/howpublished">http://purl.org/cg/terms/howpublished</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>How it was published, if the publishing method is nonstandard</td></tr>
-                    <tr><td class="theme-label">Comments</td><td></td></tr>
-                    <tr><td class="theme-label">Examples</td><td></td></tr>
-                </tbody>
-            </table>
-
-            <p class="invisible">
-                <a id="cg:journal"></a><a id="journal"></a></p>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-secondary"><th colspan="2">journal <span class="badge badge-secondary float-right">Property</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/journal">http://purl.org/cg/terms/journal</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>The journal name</td></tr>
-                    <tr><td class="theme-label">Comments</td><td></td></tr>
-                    <tr><td class="theme-label">Examples</td><td></td></tr>
-                </tbody>
-            </table>
-
-            <p class="invisible">
-                <a id="cg:booktitle"></a><a id="booktitle"></a></p>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-secondary"><th colspan="2">booktitle <span class="badge badge-secondary float-right">Property</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/booktitle">http://purl.org/cg/terms/booktitle</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>The title of the book, if only part of it is being cited</td></tr>
-                    <tr><td class="theme-label">Comments</td><td></td></tr>
-                    <tr><td class="theme-label">Examples</td><td></td></tr>
-                </tbody>
-            </table>
-
-            <p class="invisible">
-                <a id="cg:chapter"></a><a id="chapter"></a></p>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-secondary"><th colspan="2">chapter <span class="badge badge-secondary float-right">Property</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/chapter">http://purl.org/cg/terms/chapter</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>The chapter number</td></tr>
-                    <tr><td class="theme-label">Comments</td><td></td></tr>
-                    <tr><td class="theme-label">Examples</td><td></td></tr>
-                </tbody>
-            </table>
-
-            <p class="invisible">
-                <a id="cg:pages"></a><a id="pages"></a></p>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-secondary"><th colspan="2">pages <span class="badge badge-secondary float-right">Property</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/pages">http://purl.org/cg/terms/pages</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>Page numbers</td></tr>
-                    <tr><td class="theme-label">Comments</td><td></td></tr>
-                    <tr><td class="theme-label">Examples</td><td></td></tr>
-                </tbody>
-            </table>
-
-            <p class="invisible">
-                <a id="cg:volume"></a><a id="volume"></a></p>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-secondary"><th colspan="2">volume <span class="badge badge-secondary float-right">Property</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/volume">http://purl.org/cg/terms/volume</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>The volume of a journal or multi-volume book</td></tr>
-                    <tr><td class="theme-label">Comments</td><td></td></tr>
-                    <tr><td class="theme-label">Examples</td><td></td></tr>
-                </tbody>
-            </table>
-
-            <p class="invisible">
-                <a id="cg:number"></a><a id="number"></a></p>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-secondary"><th colspan="2">number <span class="badge badge-secondary float-right">Property</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/number">http://purl.org/cg/terms/number</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>The "(issue) number" of a journal, magazine, or tech-report</td></tr>
-                    <tr><td class="theme-label">Comments</td><td></td></tr>
-                    <tr><td class="theme-label">Examples</td><td></td></tr>
-                </tbody>
-            </table>
-
-            <p class="invisible">
-                <a id="dct:extent"></a><a id="extent"></a></p>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-secondary"><th colspan="2">extent<span class="badge badge-secondary float-right">Property</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/dc/terms/extent">http://purl.org/dc/terms/extent</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>The size or duration of the resource</td></tr>
-                    <tr><td class="theme-label">Comments</td><td></td></tr>
-                    <tr><td class="theme-label">Examples</td><td><code>p. 1159-1179</code> , <code>47 p.</code> , <code>185-211 p.</code> , <code>65(2): 200-206</code> , <code>1-13</code></td></tr>
-                </tbody>
-            </table>
-
-            <p class="invisible">
-                <a id="cg:series"></a><a id="series"></a></p>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-secondary"><th colspan="2">series <span class="badge badge-secondary float-right">Property</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/series">http://purl.org/cg/terms/series</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>The series of books the book was published in</td></tr>
-                    <tr><td class="theme-label">Comments</td><td></td></tr>
-                    <tr><td class="theme-label">Examples</td><td>Lecture Notes in Computer Science</td></tr>
-                </tbody>
-            </table>
-
-            <p class="invisible">
-                <a id="cg:edition"></a><a id="edition"></a></p>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-secondary"><th colspan="2">edition <span class="badge badge-secondary float-right">Property</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/edition">http://purl.org/cg/terms/edition</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>The edition of a book, long form</td></tr>
-                    <tr><td class="theme-label">Comments</td><td></td></tr>
-                    <tr><td class="theme-label">Examples</td><td>First Edition</td></tr>
-                </tbody>
-            </table>
-
-            <p class="invisible">
-                <a id="cg:notes"></a><a id="notes"></a></p>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-secondary"><th colspan="2">notes <span class="badge badge-secondary float-right">Property</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/notes">http://purl.org/cg/terms/notes</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>Miscellaneous extra information related to a scientific publication </td></tr>
-                    <tr><td class="theme-label">Comments</td><td></td></tr>
-                    <tr><td class="theme-label">Examples</td><td></td></tr>
-                </tbody>
-            </table>
-
-             <p class="invisible">
-                <a id="dct:audience"></a><a id="audience"></a></p>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-secondary"><th colspan="2">audience <span class="badge badge-secondary float-right">Property</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/dc/terms/audience">http://purl.org/dc/terms/audience</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>A class of entity for whom the resource is intended or useful.</td></tr>
-                    <tr><td class="theme-label">Comments</td><td>Should be populated using 'Agent Class', which include groups seen as classes, such as students, women, charities, lecturers.</td></tr>
-                    <tr><td class="theme-label">Examples</td><td><code>'Students'</code></td></tr>
-                </tbody>
-            </table>
-
-            <p class="invisible">
-                <a id="dct:isPartOf"></a><a id="abstract"></a></p>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-secondary"><th colspan="2">isPartOf <span class="badge badge-secondary float-right">Property</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/dc/terms/isPartOf">http://purl.org/dc/terms/isPartOf</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>A related resource in which the described resource is physically or logically included</td></tr>
-                    <tr><td class="theme-label">Comments</td><td>Should be used to link a book to a series</td></tr>
-                    <tr><td class="theme-label">Examples</td><td></td></tr>
-                </tbody>
-            </table>
-
-            <h2 id="concept">Concept</h2>
-
-            <div class="my-4">
-                    <a class="btn btn-sm btn-outline-secondary m-1" href="#cg:label">label</a>
-                    <a class="btn btn-sm btn-outline-secondary m-1" href="#cg:vocab">vocab</a>
-                    <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:identifier">identifier</a>
-                </div>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-primary"><th colspan="2">Concept <span class="badge badge-primary float-right">Class</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/Concept">http://purl.org/cg/terms/Concept</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>A a unit of thought e.g. skos:concept, owl:class or simple keywords</td></tr>
-                    <tr><td class="theme-label">Comments</td><td></td></tr>
-                    <tr><td class="theme-label">Examples</td><td></td></tr>
-                </tbody>
-            </table>
-
-            <p class="invisible">
-                <a id="cg:label"></a><a id="label"></a></p>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-secondary"><th colspan="2">Label <span class="badge badge-secondary float-right">Property</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://www.w3.org/2000/01/rdf-schema#label">http://www.w3.org/2000/01/rdf-schema#label</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>The label of the concept</td></tr>
-                    <tr><td class="theme-label">Comments</td><td>Should be the preferred label if a concept has several labels</td></tr>
-                    <tr><td class="theme-label">Examples</td><td></td></tr>
-                </tbody>
-            </table>
-
-            <p class="invisible">
-                <a id="cg:vocab"></a><a id="vocab"></a></p>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-secondary"><th colspan="2">vocab <span class="badge badge-secondary float-right">Property</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/cg/terms/vocab">http://purl.org/cg/terms/vocab</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>Source of the concept</td></tr>
-                    <tr><td class="theme-label">Comments</td><td>One of the following: AGROVOC, GACS, AgrO, CO</td></tr>
-                    <tr><td class="theme-label">Examples</td><td>AGROVOC</td></tr>
-                </tbody>
-            </table>
-
-            <p class="invisible">
-                <a id="dcterms:identifier"></a><a id="identifer"></a></p>
-
-            <table class="table table-sm table-bordered">
-                <tbody>
-                    <tr class="table-secondary"><th colspan="2">identifier <span class="badge badge-secondary float-right">Property</span></th></tr>
-                    <tr><td class="theme-label">Identifier</td><td><a href="http://purl.org/dc/terms/identifier">http://purl.org/dc/terms/identifier</a></td></tr>
-                    <tr><td class="theme-label">Definition</td><td>URI of the concept</td></tr>
-                    <tr><td class="theme-label">Comments</td><td></td></tr>
-                    <tr><td class="theme-label">Examples</td><td><a href="http://aims.fao.org/aos/agrovoc/c_7771">http://aims.fao.org/aos/agrovoc/c_7771</a></td></tr>
-                </tbody>
-            </table>
-        </div>
-    </body>
+  </style>
+</head>
+<body>
+  <div>
+    <hr>
+    <div id="titleP">
+      <h1 id="cgcoremetadatareferenceguide">CG Core metadata reference guide</h1>
+      <p>This page provides a list of the metadata elements that are used in the CG Core metadata schema. The CG Core metadata schema is an application profile and is built from existing standards as much as possible. It is an effort led by the Big Data Platform Metadata Working Group of the CGIAR.</p>
+      <p>The CG Core aims at describing all types of information products that are published by the different CGIAR centres. There are many benefits of having a clear and harmonised way to describe information products:</p>
+      <ul>
+        <li>better interoperability</li>
+        <li>better transparency</li>
+        <li>easy monitoring</li>
+      </ul>
+      <p>This document provides guidelines on how to use the CG Core metadata schema and provides examples on how to use it. A RDF version of the application profile will be available soon.</p>
+    </div>
+    <div class="my">
+      <h3>Quick jump</h3><a class="btn btn-sm btn-outline-secondary m-0" href="#informationproduct">Information product</a> <a class="btn btn-sm btn-outline-secondary m-0" href="#Creator">Creator</a> <a class="btn btn-sm btn-outline-secondary m-0" href="#Contributor">Contributor</a> <a class="btn btn-sm btn-outline-secondary m-0" href="#Coverage">Coverage</a> <a class="btn btn-sm btn-outline-secondary m-0" href="#scientificpublication">Scientific Publication</a> <a class="btn btn-sm btn-outline-secondary m-0" href="#concept">Concept</a>
+    </div>
+    <h2 id="informationproduct">Information product</h2>
+    <div class="my-4">
+      <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:identfier">identifier</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:title">title</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:description">description</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:type">type</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:language">language</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:license">license</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:rightsHolder">rightsHolder</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:accessRights">accessRights</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:subject">subject</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:issued">issued</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#cg:embargoDate">embargoDate</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:creator">creator</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:contributor">contributor</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:coverage">coverage</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:relation">relation</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#cg:HasMetadata">hasMetadata</a>
+    </div>
+    <p class="invisible"><a id="dcterms:identifier"></a><a id="identifier"></a></p>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-secondary">
+          <th colspan="2">identifier <span class="badge badge-secondary float-right">Property</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://purl.org/dc/terms/identifier">http://purl.org/dc/terms/identifier</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>An unambiguous reference to the resource within a given context.</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td>Recommended best practice is to identify the resource by using a DOI or an handle</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td></td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="invisible"><a id="dcterms:title"></a><a id="title"></a></p>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-secondary">
+          <th colspan="2">title <span class="badge badge-secondary float-right">Property</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://purl.org/dc/terms/title">http://purl.org/dc/terms/title</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>A name given to the resource</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td>Follow standard title formatting for capitalization and punctuation.</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td><code>'Managing for timber and biodiversity in the Congo basin' -- 'A 2007 Social Accounting Matrix for China' -- '2012 Global Hunger Index Data'</code></td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="invisible"><a id="dcterms:description"></a><a id="description"></a></p>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-secondary">
+          <th colspan="2">description <span class="badge badge-secondary float-right">Property</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://purl.org/dc/terms/description">http://purl.org/dc/terms/description</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>Description may include but is not limited to: an abstract, a table of contents, a graphical representation, or a free-text account of the resource.</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td>Descriptive details significantly improve discoverability via search engines such as Google and Bing, and will aid interlink between related resources at the meta-search/indexer level. Descriptions can be provided in multiple languages if appropriate and available.</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td></td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="invisible"><a id="dcterms:type"></a><a id="type"></a></p>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-secondary">
+          <th colspan="2">type <span class="badge badge-secondary float-right">Property</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://purl.org/dc/terms/type">http://purl.org/dc/terms/type</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>The nature or genre of the resource</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td>
+            Must be populated with a value from the local <a href="IPtypes.html">Type</a> and subType lists
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td><code>Datafile</code></td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="invisible"><a id="dcterms:language"></a><a id="language"></a></p>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-secondary">
+          <th colspan="2">language <span class="badge badge-secondary float-right">Property</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://purl.org/dc/terms/language">http://purl.org/dc/terms/language</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>A language of the resource.</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td>ISO 639-2 (alpha-3)</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td><code>eng</code></td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="invisible"><a id="dcterms:license"></a><a id="license"></a></p>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-secondary">
+          <th colspan="2">license <span class="badge badge-secondary float-right">Property</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://purl.org/dc/terms/license">http://purl.org/dc/terms/license</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>A legal document giving official permission to do something with the resource.</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td>
+            List of licenses from <a href="https://spdx.org/licenses/">SPDX</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td><code><a href="http://creativecommons.org/licenses/by/4.0/legalcode">http://creativecommons.org/licenses/by/4.0/legalcode</a></code></td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="invisible"><a id="dcterms:rightsHolder"></a><a id="rightsHolder"></a></p>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-secondary">
+          <th colspan="2">rightsHolder <span class="badge badge-secondary float-right">Property</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://purl.org/dc/terms/rightsHolder">http://purl.org/dc/terms/rightsHolder</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>A person or organisation owning or managing rights over the resource.</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td></td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td><code>CIAT</code></td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="invisible"><a id="dcterms:accessRights"></a><a id="accessRights"></a></p>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-secondary">
+          <th colspan="2">accessRights <span class="badge badge-secondary float-right">Property</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://purl.org/dc/terms/accessRights">http://purl.org/dc/terms/accessRights</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>Information about who can access the resource or an indication of its security status. Access Rights may include information regarding access or restrictions based on privacy, security, or other policies.</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td>Values should come from the following list: "open", "restricted"</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td><code>open</code></td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="invisible"><a id="dcterms:subject"></a><a id="subject"></a></p>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-secondary">
+          <th colspan="2">subject <span class="badge badge-secondary float-right">Property</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://purl.org/dc/terms/subject">http://purl.org/dc/terms/subject</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>keywords describing the subject of the information product.</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td>To be used to link the resource to one or more concept</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td></td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="invisible"><a id="dcterms:issued"></a><a id="issued"></a></p>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-secondary">
+          <th colspan="2">issued <span class="badge badge-secondary float-right">Property</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://purl.org/dc/terms/issued">http://purl.org/dc/terms/issued</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>Date of formal issuance (e.g., publication) of the resource</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td>The date when the information product was created in its final form to be published</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td></td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="invisible"><a id="cg:embargoDate"></a><a id="embargoDate"></a></p>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-secondary">
+          <th colspan="2">embargoDate <span class="badge badge-secondary float-right">Property</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://purl.org/cg/terms/embargoDate">http://purl.org/cg/terms/embargoDate</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>In cases when the information product has an embargo this date indicates when it would be available.</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td></td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td></td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="invisible"><a id="dcterms:creator"></a><a id="creator"></a></p>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-secondary">
+          <th colspan="2">creator <span class="badge badge-secondary float-right">Property</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://purl.org/dc/terms/creator">http://purl.org/dc/terms/creator</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>To be used to link the resource to one or more creator objects</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td>This term is intended to be used with non-literal values</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td></td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="invisible"><a id="dcterms:contributor"></a><a id="contributor"></a></p>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-secondary">
+          <th colspan="2">contributor <span class="badge badge-secondary float-right">Property</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://purl.org/dc/terms/contributor">http://purl.org/dc/terms/contributor</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>To be used to link the resource to one or more contributor objects</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td>This term is intended to be used with non-literal values</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td></td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="invisible"><a id="dcterms:coverage"></a><a id="coverage"></a></p>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-secondary">
+          <th colspan="2">coverage <span class="badge badge-secondary float-right">Property</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://purl.org/dc/terms/coverage">http://purl.org/dc/terms/coverage</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>To be used to link the resource to one or more coverage objects</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td>This term is intended to be used with non-literal values</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td></td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="invisible"><a id="dcterms:relation"></a><a id="relation"></a></p>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-secondary">
+          <th colspan="2">relation <span class="badge badge-secondary float-right">Property</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://purl.org/dc/terms/relation">http://purl.org/dc/terms/relation</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>A related resource</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td>This term is intended to be used with non-literal values. Should be use to link a dataset to its related publication(s) and reciprocally</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td></td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="invisible"><a id="cg:HasMetadata"></a><a id="HasMetadata"></a></p>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-secondary">
+          <th colspan="2">hasMetadata <span class="badge badge-secondary float-right">Property</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://purl.org/cg/terms/hasMetadata">http://purl.org/cg/terms/hasMetadata</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>A related resource that is the metadata record for the measured variables of the described dataset</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td>This term is intended to be used with non-literal values.</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td></td>
+        </tr>
+      </tbody>
+    </table>
+    <h2 id="Creator">Creator</h2>
+    <div class="my-4">
+      <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:identifier">identifier</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#cg:affiliation">affiliation</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#cg:creator%20name">name</a>
+    </div>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-primary">
+          <th colspan="2">Creator <span class="badge badge-primary float-right">Class</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://purl.org/cg/terms/Creator">http://purl.org/cg/terms/Creator</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>The author(s), researcher(s), scientist(s) responsible for producing the information product</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td></td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td></td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="invisible"><a id="dcterms:identifier"></a><a id="identifer"></a></p>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-secondary">
+          <th colspan="2">identifier <span class="badge badge-secondary float-right">Property</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://purl.org/dc/terms/identifier">http://purl.org/dc/terms/identifier</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>ORCID</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td></td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td></td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="invisible"><a id="cg:affiliation"></a><a id="affiliation"></a></p>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-secondary">
+          <th colspan="2">affiliation <span class="badge badge-secondary float-right">Property</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://purl.org/cg/terms/affiliation">http://purl.org/cg/terms/affiliation</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>the affiliation of the creator</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td>
+            Must be populated with a value coming from the CLARISA <a href="https://clarisa.cgiar.org/api/institutions">institution list</a> or the <a href="https://www.grid.ac/">grid</a> list
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td><code>Bioversity International</code></td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="invisible"><a id="cg:creator name"></a><a id="name"></a></p>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-secondary">
+          <th colspan="2">name <span class="badge badge-secondary float-right">Property</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://xmlns.com/foaf/0.1/name">http://xmlns.com/foaf/0.1/name</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>The full name identifying the creator</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td></td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td></td>
+        </tr>
+      </tbody>
+    </table>
+    <h2 id="Contributor">Contributor</h2>
+    <div class="my-4">
+      <a class="btn btn-sm btn-outline-secondary m-1" href="#cg:contributor%20name">contributor name</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#cg:contributor%20type">type</a>
+    </div>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-primary">
+          <th colspan="2">Contributor <span class="badge badge-primary float-right">Class</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://purl.org/cg/terms/Contributor">http://purl.org/cg/terms/Contributor</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>Organisation, or service making contributions to the information product.</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td>describe one of the following: "Project", "Project Lead Entity", "Partner", "CRP", "Donor"</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td></td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="invisible"><a id="cg:contributor name"></a><a id="name"></a></p>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-secondary">
+          <th colspan="2">name <span class="badge badge-secondary float-right">Property</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://xmlns.com/foaf/0.1/name">http://xmlns.com/foaf/0.1/name</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>The name identifying the contributor</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td>
+            <ul>
+              <li>for donors, recommendation to use <a href="https://www.crossref.org/services/funder-registry/">crossref Donors registry</a>
+              </li>
+              <li>for CRPs and Project Lead Entity, recommendation to use <a href="https://clarisa.cgiar.org/api/cgiar-entities">CLARISA entity list</a>
+              </li>
+              <li>for partners, recommendation to use <a href="https://clarisa.cgiar.org/api/institutions">CLARISA institution list</a>
+              </li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td></td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="invisible"><a id="cg:contributor type"></a><a id="type"></a></p>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-secondary">
+          <th colspan="2">type<span class="badge badge-secondary float-right">Property</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://purl.org/dc/terms/type">http://purl.org/dc/terms/type</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>The type of contributor the contributor</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td>one of these values: "Project", "Project Lead Entity", "Partner", "CRP", "Donor"</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td></td>
+        </tr>
+      </tbody>
+    </table>
+    <h2 id="Coverage">Coverage</h2>
+    <div class="my-4">
+      <a class="btn btn-sm btn-outline-secondary m-1" href="#cgcoverage%20type">type</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#spatial">spatial coverage</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#temporal">temporal coverage</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#label">label</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#cgcoverage%20identifier">identifier</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#cg:code">code</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#cg:xCoord">xCoord</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#cg:yCoord">yCoord</a>
+    </div>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-primary">
+          <th colspan="2">Coverage <span class="badge badge-primary float-right">Class</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://purl.org/cg/terms/coverage">http://purl.org/cg/terms/coverage</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>Spatial or temporal coverage</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td></td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td></td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="invisible"><a id="cgcoverage type"></a><a id="type"></a></p>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-secondary">
+          <th colspan="2">type <span class="badge badge-secondary float-right">Property</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://purl.org/dc/terms/type">http://purl.org/dc/terms/type</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>The nature or genre of the coverage information</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td>Must be populated with a value coming from the Coverage type list</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td><code>"Spatial", "Temporal," "Region", "Country", "Administrative Unit", "AEZ", "X", "Y"</code></td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="invisible"><a id="#spatial"></a><a id="spatial"></a></p>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-secondary">
+          <th colspan="2">Spatial Coverage<span class="badge badge-secondary float-right">Property</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://purl.org/dc/terms/spatial">http://purl.org/dc/terms/spatial</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>Spatial characteristics of the resource.</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td></td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td></td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="invisible"><a id="#temporal"></a><a id="temporal"></a></p>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-secondary">
+          <th colspan="2">Temporal Coverage <span class="badge badge-secondary float-right">Property</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://purl.org/dc/terms/temportal">http://purl.org/dc/terms/temporal</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>Temporal characteristics of the resource.</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td>Should point to an interval of time that is named or defined by its start and end dates.</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td></td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="invisible"><a id="#label"></a><a id="label"></a></p>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-secondary">
+          <th colspan="2">Label <span class="badge badge-secondary float-right">Property</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://www.w3.org/2000/01/rdf-schema#label">http://www.w3.org/2000/01/rdf-schema#label</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>Label of the spatial zone</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td></td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td></td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="invisible"><a id="cgcoverage identifier"></a><a id="identifier"></a></p>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-secondary">
+          <th colspan="2">Identifier<span class="badge badge-secondary float-right">Property</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="ttp://purl.org/dc/terms/identifier">http://purl.org/dc/terms/identifier</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>Identifier of the spatial unit</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td></td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td></td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="invisible"><a id="#cg:code"></a><a id="code"></a></p>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-secondary">
+          <th colspan="2">Code<span class="badge badge-secondary float-right">Property</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://purl.org/cg/terms/code">http://purl.org/cg/terms/code</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>Code of the agroecological zone as defined by FAO</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td></td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td><code>101</code></td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="invisible"><a id="#cg:xCoord"></a><a id="xCoord"></a></p>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-secondary">
+          <th colspan="2">xCoord<span class="badge badge-secondary float-right">Property</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://purl.org/cg/terms/xCoord">http://purl.org/cg/terms/xCoord</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>x coordinate, in decimal degrees</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td></td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td></td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="invisible"><a id="#cg:yCoord"></a><a id="yCoord"></a></p>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-secondary">
+          <th colspan="2">yCoord<span class="badge badge-secondary float-right">Property</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://purl.org/cg/terms/yCoord">http://purl.org/cg/terms/yCoord</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>y coordinate, in decimal degrees</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td></td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td></td>
+        </tr>
+      </tbody>
+    </table>
+    <h2 id="scientificpublication">Scientific Publication</h2>
+    <div class="my-4">
+      <a class="btn btn-sm btn-outline-secondary m-1" href="#dct:abstract">abstract</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#dct:bibliographicCitation">bibliographicCitation</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#dct:publisher">publisher</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#cg:issn">issn</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#cg:isbn">isbn</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#cg:peer-reviewed">peer-reviewed</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#dct:alternative">alternative title</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#cg:howpublished">howpublished</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#cg:journal">journal</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#cg:booktitle">booktitle</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#cg:chapter">chapter</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#cg:pages">pages</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#cg:volume">volume</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#cg:number">number</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#dct:extent">extent</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#cg:series">series</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#cg:edition">edition</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#cg:notes">notes</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#dct:audience">audience</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#dct:isPartOf">isPartOf</a>
+    </div>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-primary">
+          <th colspan="2">Scientific Publication <span class="badge badge-primary float-right">Class</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://purl.org/cg/terms/ScientificPublication">http://purl.org/cg/terms/ScientificPublication</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>Specific Information Product type covering publications</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td></td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td></td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="invisible"><a id="dct:abstract"></a><a id="abstract"></a></p>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-secondary">
+          <th colspan="2">abstract <span class="badge badge-secondary float-right">Property</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://purl.org/dc/terms/abstract">http://purl.org/dc/terms/abstract</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>A summary of the resource</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td>
+            refines <a href="http://purl.org/dc/terms/description">dct:description</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td></td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="invisible"><a id="dct:bibliographicCitation"></a><a id="bibliographicCitation"></a></p>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-secondary">
+          <th colspan="2">bibliographicCitation <span class="badge badge-secondary float-right">Property</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://purl.org/dc/terms/bibliographicCitation">http://purl.org/dc/terms/bibliographicCitation</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>A bibliographic reference for the resource</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td>
+            Recommended practice is to include sufficient bibliographic detail to identify the resource as unambiguously as possible. Refines <a href="http://purl.org/dc/terms/identifier">dct:identifier</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td></td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="invisible"><a id="dct:publisher"></a><a id="publisher"></a></p>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-secondary">
+          <th colspan="2">publisher<span class="badge badge-secondary float-right">Property</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://purl.org/dc/terms/publisher">http://purl.org/dc/terms/publisher</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>An entity responsible for making the resource available</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td>Here, the publisher of the scientific publication</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td></td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="invisible"><a id="cg:issn"></a><a id="issn"></a></p>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-secondary">
+          <th colspan="2">issn<span class="badge badge-secondary float-right">Property</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://purl.org/cg/terms/issn">http://purl.org/cg/terms/issn</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>Used to record ISSN number</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td>
+            Refines <a href="http://purl.org/dc/terms/identifier">dct:identifier</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td></td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="invisible"><a id="cg:isbn"></a><a id="isbn"></a></p>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-secondary">
+          <th colspan="2">isbn<span class="badge badge-secondary float-right">Property</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://purl.org/cg/terms/isbn">http://purl.org/cg/terms/isbn</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>Used to record ISBN number</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td>
+            Refines <a href="http://purl.org/dc/terms/identifier">dct:identifier</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td></td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="invisible"><a id="cg:peer-reviewed"></a><a id="peer-reviewed"></a></p>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-secondary">
+          <th colspan="2">peer-reviewed <span class="badge badge-secondary float-right">Property</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://purl.org/cg/terms/peer-reviewed">http://purl.org/cg/terms/peer-reviewed</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>If the resource has been peer reviewed</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td></td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td>true is peer-reviewed, not used if not</td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="invisible"><a id="dct:alternative"></a><a id="alternative"></a></p>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-secondary">
+          <th colspan="2">Alternative Title<span class="badge badge-secondary float-right">Property</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://purl.org/dc/terms/abstract">http://purl.org/dc/terms/alternative</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>An alternative name for the resource.</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td>
+            refines <a href="http://purl.org/dc/terms/title">dct:title</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td></td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="invisible"><a id="cg:howpublished"></a><a id="howpublished"></a></p>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-secondary">
+          <th colspan="2">howpublished <span class="badge badge-secondary float-right">Property</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://purl.org/cg/terms/howpublished">http://purl.org/cg/terms/howpublished</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>How it was published, if the publishing method is nonstandard</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td></td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td></td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="invisible"><a id="cg:journal"></a><a id="journal"></a></p>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-secondary">
+          <th colspan="2">journal <span class="badge badge-secondary float-right">Property</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://purl.org/cg/terms/journal">http://purl.org/cg/terms/journal</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>The journal name</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td></td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td></td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="invisible"><a id="cg:booktitle"></a><a id="booktitle"></a></p>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-secondary">
+          <th colspan="2">booktitle <span class="badge badge-secondary float-right">Property</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://purl.org/cg/terms/booktitle">http://purl.org/cg/terms/booktitle</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>The title of the book, if only part of it is being cited</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td></td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td></td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="invisible"><a id="cg:chapter"></a><a id="chapter"></a></p>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-secondary">
+          <th colspan="2">chapter <span class="badge badge-secondary float-right">Property</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://purl.org/cg/terms/chapter">http://purl.org/cg/terms/chapter</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>The chapter number</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td></td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td></td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="invisible"><a id="cg:pages"></a><a id="pages"></a></p>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-secondary">
+          <th colspan="2">pages <span class="badge badge-secondary float-right">Property</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://purl.org/cg/terms/pages">http://purl.org/cg/terms/pages</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>Page numbers</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td></td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td></td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="invisible"><a id="cg:volume"></a><a id="volume"></a></p>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-secondary">
+          <th colspan="2">volume <span class="badge badge-secondary float-right">Property</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://purl.org/cg/terms/volume">http://purl.org/cg/terms/volume</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>The volume of a journal or multi-volume book</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td></td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td></td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="invisible"><a id="cg:number"></a><a id="number"></a></p>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-secondary">
+          <th colspan="2">number <span class="badge badge-secondary float-right">Property</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://purl.org/cg/terms/number">http://purl.org/cg/terms/number</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>The "(issue) number" of a journal, magazine, or tech-report</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td></td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td></td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="invisible"><a id="dct:extent"></a><a id="extent"></a></p>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-secondary">
+          <th colspan="2">extent<span class="badge badge-secondary float-right">Property</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://purl.org/dc/terms/extent">http://purl.org/dc/terms/extent</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>The size or duration of the resource</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td></td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td><code>p. 1159-1179</code> , <code>47 p.</code> , <code>185-211 p.</code> , <code>65(2): 200-206</code> , <code>1-13</code></td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="invisible"><a id="cg:series"></a><a id="series"></a></p>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-secondary">
+          <th colspan="2">series <span class="badge badge-secondary float-right">Property</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://purl.org/cg/terms/series">http://purl.org/cg/terms/series</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>The series of books the book was published in</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td></td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td>Lecture Notes in Computer Science</td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="invisible"><a id="cg:edition"></a><a id="edition"></a></p>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-secondary">
+          <th colspan="2">edition <span class="badge badge-secondary float-right">Property</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://purl.org/cg/terms/edition">http://purl.org/cg/terms/edition</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>The edition of a book, long form</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td></td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td>First Edition</td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="invisible"><a id="cg:notes"></a><a id="notes"></a></p>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-secondary">
+          <th colspan="2">notes <span class="badge badge-secondary float-right">Property</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://purl.org/cg/terms/notes">http://purl.org/cg/terms/notes</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>Miscellaneous extra information related to a scientific publication</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td></td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td></td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="invisible"><a id="dct:audience"></a><a id="audience"></a></p>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-secondary">
+          <th colspan="2">audience <span class="badge badge-secondary float-right">Property</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://purl.org/dc/terms/audience">http://purl.org/dc/terms/audience</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>A class of entity for whom the resource is intended or useful.</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td>Should be populated using 'Agent Class', which include groups seen as classes, such as students, women, charities, lecturers.</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td><code>'Students'</code></td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="invisible"><a id="dct:isPartOf"></a><a id="abstract"></a></p>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-secondary">
+          <th colspan="2">isPartOf <span class="badge badge-secondary float-right">Property</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://purl.org/dc/terms/isPartOf">http://purl.org/dc/terms/isPartOf</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>A related resource in which the described resource is physically or logically included</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td>Should be used to link a book to a series</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td></td>
+        </tr>
+      </tbody>
+    </table>
+    <h2 id="concept">Concept</h2>
+    <div class="my-4">
+      <a class="btn btn-sm btn-outline-secondary m-1" href="#cg:label">label</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#cg:vocab">vocab</a> <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:identifier">identifier</a>
+    </div>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-primary">
+          <th colspan="2">Concept <span class="badge badge-primary float-right">Class</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://purl.org/cg/terms/Concept">http://purl.org/cg/terms/Concept</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>A a unit of thought e.g. skos:concept, owl:class or simple keywords</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td></td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td></td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="invisible"><a id="cg:label"></a><a id="label"></a></p>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-secondary">
+          <th colspan="2">Label <span class="badge badge-secondary float-right">Property</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://www.w3.org/2000/01/rdf-schema#label">http://www.w3.org/2000/01/rdf-schema#label</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>The label of the concept</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td>Should be the preferred label if a concept has several labels</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td></td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="invisible"><a id="cg:vocab"></a><a id="vocab"></a></p>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-secondary">
+          <th colspan="2">vocab <span class="badge badge-secondary float-right">Property</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://purl.org/cg/terms/vocab">http://purl.org/cg/terms/vocab</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>Source of the concept</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td>One of the following: AGROVOC, GACS, AgrO, CO</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td>AGROVOC</td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="invisible"><a id="dcterms:identifier"></a><a id="identifer"></a></p>
+    <table class="table table-sm table-bordered">
+      <tbody>
+        <tr class="table-secondary">
+          <th colspan="2">identifier <span class="badge badge-secondary float-right">Property</span></th>
+        </tr>
+        <tr>
+          <td class="theme-label">Identifier</td>
+          <td>
+            <a href="http://purl.org/dc/terms/identifier">http://purl.org/dc/terms/identifier</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="theme-label">Definition</td>
+          <td>URI of the concept</td>
+        </tr>
+        <tr>
+          <td class="theme-label">Comments</td>
+          <td></td>
+        </tr>
+        <tr>
+          <td class="theme-label">Examples</td>
+          <td>
+            <a href="http://aims.fao.org/aos/agrovoc/c_7771">http://aims.fao.org/aos/agrovoc/c_7771</a>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</body>
 </html>


### PR DESCRIPTION
This makes the files easier to read and removes the need to manually format them. Eventually this would be part of a git pre-commit hook. There are still a few warnings during validation that we should fix. Previous fixes were done in #16.

Using `tidy` on Linux or macOS:

    $ tidy -utf8 -m -iq -w 0 cgcore.html
    $ tidy -utf8 -m -iq -w 0 IPtypes.html